### PR TITLE
Memory optimization

### DIFF
--- a/GDEdit/GDEdit/Application/Editor/Editor.cs
+++ b/GDEdit/GDEdit/Application/Editor/Editor.cs
@@ -240,7 +240,7 @@ namespace GDEdit.Application.Editor
         /// <summary>Scales the selected objects by an amount.</summary>
         /// <param name="scaling">The scaling to apply to all the objects.</param>
         /// <param name="individually">Determines whether the objects will be only scaled individually.</param>
-        public void Scale(double scaling, bool individually)
+        public void Scale(float scaling, bool individually)
         {
             foreach (var o in Level.LevelObjects)
                 o.Scaling *= scaling;
@@ -254,7 +254,7 @@ namespace GDEdit.Application.Editor
         /// <summary>Scales the selected objects by an amount based on a specific central point.</summary>
         /// <param name="scaling">The scaling to apply to all the objects.</param>
         /// <param name="center">The central point to take into account while scaling all objects.</param>
-        public void Scale(double scaling, Point center)
+        public void Scale(float scaling, Point center)
         {
             foreach (var o in Level.LevelObjects)
             {

--- a/GDEdit/GDEdit/GDEdit.csproj
+++ b/GDEdit/GDEdit/GDEdit.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Utilities\Information\GeometryDash\PreviousVersions.cs" />
     <Compile Include="Utilities\Information\GeometryDash\Speeds.cs" />
     <Compile Include="Utilities\Objects\General\Point.cs" />
+    <Compile Include="Utilities\Objects\General\BitArray8.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\CustomLevelObject.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\General\BoundedDouble.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\General\HSVDifference.cs" />

--- a/GDEdit/GDEdit/Utilities/Functions/GeometryDash/ColorTriggerTypes.cs
+++ b/GDEdit/GDEdit/Utilities/Functions/GeometryDash/ColorTriggerTypes.cs
@@ -29,12 +29,12 @@ namespace GDEdit.Utilities.Functions.GeometryDash
                 case TriggerType.ThreeDL:
                     return SpecialColorID.ThreeDL;
                 default:
-                    throw new Exception("Invalid color trigger type");
+                    throw new ArgumentException("Invalid color trigger type");
             }
         }
         /// <summary>Returns the Color ID the color trigger represents.</summary>
         /// <param name="trigger">The color trigger whose target Color ID to retrieve.</param>
-        public static int ConvertToColorID(TriggerType trigger)
+        public static short ConvertToColorID(TriggerType trigger)
         {
             switch (trigger)
             {
@@ -47,7 +47,7 @@ namespace GDEdit.Utilities.Functions.GeometryDash
                 case TriggerType.Color4:
                     return 4;
                 default:
-                    throw new Exception("Invalid color trigger type");
+                    throw new ArgumentException("Invalid color trigger type");
             }
         }
     }

--- a/GDEdit/GDEdit/Utilities/Functions/GeometryDash/Gamesave.cs
+++ b/GDEdit/GDEdit/Utilities/Functions/GeometryDash/Gamesave.cs
@@ -163,7 +163,7 @@ namespace GDEdit.Utilities.Functions.GeometryDash
                 int length1 = objectParameters.GetLength(1);
                 for (int i = 0; i < length0; i++)
                 {
-                    objects.Add(new GeneralObject(ToInt32(objectParameters[i, 1]), ToDouble(objectParameters[i, 3]), ToDouble(objectParameters[i, 5]))); // Get IDs of the selected objects
+                    objects.Add(new GeneralObject(ToInt16(objectParameters[i, 1]), ToDouble(objectParameters[i, 3]), ToDouble(objectParameters[i, 5]))); // Get IDs of the selected objects
                     for (int j = 7; j < length1; j += 2)
                     {
                         if (objectParameters[i, j] != null)
@@ -201,7 +201,7 @@ namespace GDEdit.Utilities.Functions.GeometryDash
             }
             return new LevelObjectCollection(objects);
         }
-        public static GeneralObject GetCommonAttributes(List<GeneralObject> list, int objectID)
+        public static GeneralObject GetCommonAttributes(List<GeneralObject> list, short objectID)
         {
             GeneralObject common = GeneralObject.GetNewObjectInstance(objectID);
 

--- a/GDEdit/GDEdit/Utilities/Objects/General/BitArray8.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/General/BitArray8.cs
@@ -1,0 +1,53 @@
+namespace GDEdit.Utilities.Objects.General
+{
+    /// <summary>Represents an array of 8 bits compactly stored in a <seealso cref="byte"/>.</summary>
+    public struct BitArray8
+    {
+        // The LSB has index 0 and the MSB has index 7
+        public byte bits;
+        
+        /// <summary>Initializes a new instance of the <seealso cref="BitArray8"/> struct.</summary>
+        /// <param name="defaultValue">The default value to set to all the bits.</param>
+        public BitArray8(bool defaultValue)
+        {
+            if (defaultValue)
+                bits = 0b1111_1111; // Hardcode for perfomance
+            else
+                bits = 0;
+        }
+        
+        /// <summary>Gets a bit of the <seealso cref="BitArray8"/> at the specified index as a <seealso cref="bool"/>.</summary>
+        /// <param name="index">The index of the bit to get.</param>
+        public bool GetBoolBit(int index) => GetBool(GetBit(index));
+        /// <summary>Sets a bit of the <seealso cref="BitArray8"/> at the specified index as a <seealso cref="bool"/>.</summary>
+        /// <param name="index">The index of the bit to set.</param>
+        /// <param name="b">The bit to set at the specified index as a <seealso cref="bool"/>.</param>
+        public void SetBoolBit(int index, bool b) => SetBit(index, GetByte(b));
+        
+        // All those casts are retarded
+        /// <summary>Gets a bit of the <seealso cref="BitArray8"/> at the specified index.</summary>
+        /// <param name="index">The index of the bit to get.</param>
+        public byte GetBit(int index) => (byte)((byte)(bits << (7 - index)) >> 7);
+        /// <summary>Sets a bit of the <seealso cref="BitArray8"/> at the specified index.</summary>
+        /// <param name="index">The index of the bit to set.</param>
+        /// <param name="b">The bit to set at the specified index.</param>
+        public void SetBit(int index, byte b)
+        {
+            int left = (bits >> (index + 1)) << (index + 1);
+            int right = (byte)(bits << (8 - index)) >> (8 - index);
+            bits = (byte)(left | (b << index) | right);
+        }
+        
+        /// <summary>Gets or sets a bit of the <seealso cref="BitArray8"/> at the specified index.</summary>
+        /// <param name="index">The index of the bit to get or set.</param>
+        public bool this[int index]
+        {
+            get => GetBoolBit(index);
+            set => SetBoolBit(index, value);
+        }
+        
+        // Methods are private to avoid handling exceptions
+        private static bool GetBool(byte b) => b == 1;
+        private static byte GetByte(bool b) => b ? (byte)1 : (byte)0;
+    }
+}

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
@@ -18,15 +18,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
     {
         private BitArray8 bools = new BitArray8();
         private float rotation;
-        private short objectID;
         
         /// <summary>The Object ID of this object.</summary>
         [ObjectStringMappable(ObjectParameter.ID)]
-        public int ObjectID
-        {
-            get => objectID;
-            set => objectID = (short)value;
-        }
+        public short ObjectID { get; set; }
         /// <summary>The X position of this object.</summary>
         [ObjectStringMappable(ObjectParameter.X)]
         public double X { get; set; }
@@ -154,7 +149,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
         }
         /// <summary>Creates a new instance of the <seealso cref="GeneralObject"/> class.</summary>
         /// <param name="objectID">The object ID of this <seealso cref="GeneralObject"/>.</param>
-        public GeneralObject(int objectID)
+        public GeneralObject(short objectID)
         {
             ObjectID = objectID;
         }
@@ -162,7 +157,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
         /// <param name="objectID">The object ID of this <seealso cref="GeneralObject"/>.</param>
         /// <param name="x">The X position of this <seealso cref="GeneralObject"/>.</param>
         /// <param name="y">The Y position of this <seealso cref="GeneralObject"/>.</param>
-        public GeneralObject(int objectID, double x, double y)
+        public GeneralObject(short objectID, double x, double y)
         {
             ObjectID = objectID;
             X = x;
@@ -173,7 +168,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
         /// <param name="x">The X position of this <seealso cref="GeneralObject"/>.</param>
         /// <param name="y">The Y position of this <seealso cref="GeneralObject"/>.</param>
         /// <param name="rotation">The rotation of this <seealso cref="GeneralObject"/>.</param>
-        public GeneralObject(int objectID, double x, double y, double rotation)
+        public GeneralObject(short objectID, double x, double y, double rotation)
         {
             ObjectID = objectID;
             X = x;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
@@ -203,59 +203,59 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
         /// <param name="endingY">The ending Y position of the rectangle.</param>
         public bool IsWithinRange(double startingX, double startingY, double endingX, double endingY) => startingX <= X && endingX >= X && startingY <= Y && endingY >= Y;
         
-        public static GeneralObject GetNewObjectInstance(int objectID)
+        public static GeneralObject GetNewObjectInstance(short objectID)
         {
             // TODO: Consider using reflection within this namespace
             switch (objectID)
             {
                 // Triggers
-                case (int)TriggerType.Alpha:
+                case (short)(int)TriggerType.Alpha:
                     return new AlphaTrigger();
-                case (int)TriggerType.Animate:
+                case (short)(int)TriggerType.Animate:
                     return new AnimateTrigger();
-                case (int)TriggerType.BG:
-                case (int)TriggerType.GRND:
-                case (int)TriggerType.GRND2:
-                case (int)TriggerType.ThreeDL:
-                case (int)TriggerType.Obj:
-                case (int)TriggerType.Line:
-                    return new ColorTrigger((int)ColorTriggerTypes.ConvertToSpecialColorID((TriggerType)objectID));
-                case (int)TriggerType.Color1:
-                case (int)TriggerType.Color2:
-                case (int)TriggerType.Color3:
-                case (int)TriggerType.Color4:
+                case (short)(int)TriggerType.BG:
+                case (short)(int)TriggerType.GRND:
+                case (short)(int)TriggerType.GRND2:
+                case (short)(int)TriggerType.ThreeDL:
+                case (short)(int)TriggerType.Obj:
+                case (short)(int)TriggerType.Line:
+                    return new ColorTrigger((short)(int)ColorTriggerTypes.ConvertToSpecialColorID((TriggerType)objectID));
+                case (short)(int)TriggerType.Color1:
+                case (short)(int)TriggerType.Color2:
+                case (short)(int)TriggerType.Color3:
+                case (short)(int)TriggerType.Color4:
                     return new ColorTrigger(ColorTriggerTypes.ConvertToColorID((TriggerType)objectID));
-                case (int)TriggerType.Color:
+                case (short)(int)TriggerType.Color:
                     return new ColorTrigger();
-                case (int)TriggerType.Collision:
+                case (short)(int)TriggerType.Collision:
                     return new CollisionTrigger();
-                case (int)TriggerType.Count:
+                case (short)(int)TriggerType.Count:
                     return new GeneralObject();
-                case (int)TriggerType.Follow:
+                case (short)(int)TriggerType.Follow:
                     return new FollowTrigger();
-                case (int)TriggerType.FollowPlayerY:
+                case (short)(int)TriggerType.FollowPlayerY:
                     return new FollowPlayerYTrigger();
-                case (int)TriggerType.InstantCount:
+                case (short)(int)TriggerType.InstantCount:
                     return new InstantCountTrigger();
-                case (int)TriggerType.Move:
+                case (short)(int)TriggerType.Move:
                     return new MoveTrigger();
-                case (int)TriggerType.OnDeath:
+                case (short)(int)TriggerType.OnDeath:
                     return new OnDeathTrigger();
-                case (int)TriggerType.Pickup:
+                case (short)(int)TriggerType.Pickup:
                     return new PickupTrigger();
-                case (int)TriggerType.Pulse:
+                case (short)(int)TriggerType.Pulse:
                     return new PulseTrigger();
-                case (int)TriggerType.Rotate:
+                case (short)(int)TriggerType.Rotate:
                     return new RotateTrigger();
-                case (int)TriggerType.Shake:
+                case (short)(int)TriggerType.Shake:
                     return new ShakeTrigger();
-                case (int)TriggerType.Spawn:
+                case (short)(int)TriggerType.Spawn:
                     return new SpawnTrigger();
-                case (int)TriggerType.Stop:
+                case (short)(int)TriggerType.Stop:
                     return new StopTrigger();
-                case (int)TriggerType.Toggle:
+                case (short)(int)TriggerType.Toggle:
                     return new ToggleTrigger();
-                case (int)TriggerType.Touch:
+                case (short)(int)TriggerType.Touch:
                     return new TouchTrigger();
                 // TODO: Take care of other special types of objects
                 default:

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -16,77 +16,113 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
     /// <summary>Represents a general object.</summary>
     public class GeneralObject
     {
-        private double rotation;
-
+        private BitArray8 bools = new BitArray8();
+        private float rotation;
+        private short objectID;
+        
         /// <summary>The Object ID of this object.</summary>
         [ObjectStringMappable(ObjectParameter.ID)]
-        public int ObjectID { get; set; }
+        public int ObjectID
+        {
+            get => objectID;
+            set => objectID = (short)value;
+        }
         /// <summary>The X position of this object.</summary>
-        [ObjectStringMappable((int)ObjectParameter.X)]
+        [ObjectStringMappable(ObjectParameter.X)]
         public double X { get; set; }
         /// <summary>The Y position of this object.</summary>
-        [ObjectStringMappable((int)ObjectParameter.Y)]
+        [ObjectStringMappable(ObjectParameter.Y)]
         public double Y { get; set; }
         /// <summary>Determines whether this object is flipped horizontally or not.</summary>
         [ObjectStringMappable(ObjectParameter.FlippedHorizontally)]
-        public bool FlippedHorizontally { get; set; }
+        public bool FlippedHorizontally
+        {
+            get => bools[0];
+            set => bools[0] = value;
+        }
         /// <summary>Determines whether this object is flipped vertically or not.</summary>
         [ObjectStringMappable(ObjectParameter.FlippedVertically)]
-        public bool FlippedVertically { get; set; }
+        public bool FlippedVertically
+        {
+            get => bools[1];
+            set => bools[1] = value;
+        }
         /// <summary>The rotation of this object.</summary>
-        [ObjectStringMappable((int)ObjectParameter.Rotation)]
+        [ObjectStringMappable(ObjectParameter.Rotation)]
         public double Rotation
         {
             get => rotation;
             set
             {
-                rotation = value;
-                if (rotation > 360 || rotation < -360)
-                    rotation %= 360;
+                rotation = (float)value;
+                if (rotation > 360)
+                    rotation -= 360;
+                else if (rotation < -360)
+                    rotation += 360;
             }
         }
         /// <summary>The scaling of this object.</summary>
-        [ObjectStringMappable((int)ObjectParameter.Scaling)]
-        public double Scaling { get; set; }
+        [ObjectStringMappable(ObjectParameter.Scaling)]
+        public float Scaling { get; set; }
         /// <summary>The Editor Layer 1 of this object.</summary>
         [ObjectStringMappable(ObjectParameter.EL1)]
-        public int EL1 { get; set; }
+        public short EL1 { get; set; }
         /// <summary>The Editor Layer 2 of this object.</summary>
         [ObjectStringMappable(ObjectParameter.EL2)]
-        public int EL2 { get; set; }
+        public short EL2 { get; set; }
         /// <summary>The Z Layer of this object.</summary>
         [ObjectStringMappable(ObjectParameter.ZLayer)]
-        public int ZLayer { get; set; }
+        public short ZLayer { get; set; }
         /// <summary>The Z Order of this object.</summary>
         [ObjectStringMappable(ObjectParameter.ZOrder)]
-        public int ZOrder { get; set; }
+        public short ZOrder { get; set; }
         /// <summary>The Color 1 ID of this object.</summary>
         [ObjectStringMappable(ObjectParameter.Color1)]
-        public int Color1ID { get; set; }
+        public short Color1ID { get; set; }
         /// <summary>The Color 2 ID of this object.</summary>
         [ObjectStringMappable(ObjectParameter.Color2)]
-        public int Color2ID { get; set; }
+        public short Color2ID { get; set; }
         /// <summary>The Group IDs of this object.</summary>
         [ObjectStringMappable(ObjectParameter.GroupIDs)]
-        public int[] GroupIDs { get; set; }
+        public short[] GroupIDs { get; set; }
         /// <summary>The linked group ID of this object.</summary>
         [ObjectStringMappable(ObjectParameter.LinkedGroupID)]
         public int LinkedGroupID { get; set; }
         /// <summary>Determines whether this object is the group parent or not.</summary>
         [ObjectStringMappable(ObjectParameter.GroupParent)]
-        public bool GroupParent { get; set; }
+        public bool GroupParent
+        {
+            get => bools[2];
+            set => bools[2] = value;
+        }
         /// <summary>Determines whether this object is for high detail or not.</summary>
         [ObjectStringMappable(ObjectParameter.HighDetail)]
-        public bool HighDetail { get; set; }
+        public bool HighDetail
+        {
+            get => bools[3];
+            set => bools[3] = value;
+        }
         /// <summary>Determines whether this object should have an entrance effect or not.</summary>
         [ObjectStringMappable(ObjectParameter.DontEnter)]
-        public bool DontEnter { get; set; }
+        public bool DontEnter
+        {
+            get => bools[4];
+            set => bools[4] = value;
+        }
         /// <summary>Determines whether this object should have the fade in and out disabled or not.</summary>
         [ObjectStringMappable(ObjectParameter.DontFade)]
-        public bool DontFade { get; set; }
+        public bool DontFade
+        {
+            get => bools[5];
+            set => bools[5] = value;
+        }
         /// <summary>Determines whether this object should have its glow disabled or not.</summary>
         [ObjectStringMappable(ObjectParameter.DisableGlow)]
-        public bool DisableGlow { get; set; }
+        public bool DisableGlow
+        {
+            get => bools[6];
+            set => bools[6] = value;
+        }
 
         /// <summary>Gets or sets a <seealso cref="Point"/> instance with the location of the object.</summary>
         public Point Location
@@ -110,7 +146,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
             get => MathRotationDegrees * Math.PI / 180;
             set => MathRotationDegrees = value * 180 / Math.PI;
         }
-
+        
         /// <summary>Creates a new instance of the <seealso cref="GeneralObject"/> class with the object ID parameter set to 1.</summary>
         public GeneralObject()
         {
@@ -144,10 +180,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
             Y = y;
             Rotation = rotation;
         }
-
+        
         /// <summary>Returns a clone of this object.</summary>
         public GeneralObject Clone() => (GeneralObject)MemberwiseClone();
-
+        
         public T GetParameterWithID<T>(int ID)
         {
             var properties = typeof(GeneralObject).GetProperties();
@@ -164,14 +200,14 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
                 if (((ObjectStringMappableAttribute)p.GetCustomAttributes(typeof(ObjectStringMappableAttribute), false).First()).Key == ID)
                     p.SetValue(this, newValue);
         }
-
+        
         /// <summary>Determines whether the object's location is within a rectangle.</summary>
         /// <param name="startingX">The starting X position of the rectangle.</param>
         /// <param name="startingY">The starting Y position of the rectangle.</param>
         /// <param name="endingX">The ending X position of the rectangle.</param>
         /// <param name="endingY">The ending Y position of the rectangle.</param>
         public bool IsWithinRange(double startingX, double startingY, double endingX, double endingY) => startingX <= X && endingX >= X && startingY <= Y && endingY >= Y;
-
+        
         public static GeneralObject GetNewObjectInstance(int objectID)
         {
             // TODO: Consider using reflection within this namespace

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/AnimatedObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/AnimatedObject.cs
@@ -14,7 +14,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
     public class AnimatedObject : SpecialObject
     {
         protected override int[] ValidObjectIDs => ObjectLists.AnimatedObjectList;
-        protected override string SpecialObjectType => "animated object";
+        protected override string SpecialObjectTypeName => "animated object";
 
         /// <summary>Initializes a new instance of the <seealso cref="AnimatedObject"/> class.</summary>
         /// <param name="objectID">The object ID of the animated object.</param>

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/AnimatedObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/AnimatedObject.cs
@@ -20,7 +20,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
         /// <param name="objectID">The object ID of the animated object.</param>
         /// <param name="x">The X location of the object.</param>
         /// <param name="y">The Y location of the object.</param>
-        public AnimatedObject(int objectID, double x, double y)
+        public AnimatedObject(short objectID, double x, double y)
             : base(objectID, x, y) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CollisionBlock.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CollisionBlock.cs
@@ -12,12 +12,12 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
     public class CollisionBlock : SpecialObject, IHasPrimaryBlockID
     {
         /// <summary>The object ID of the collision block.</summary>
-        public new int ObjectID => (int)Enumerations.GeometryDash.SpecialObjectType.CollisionBlock;
+        public new short ObjectID => (short)(int)SpecialObjectType.CollisionBlock;
 
         /// <summary>The Block ID of the collision block.</summary>
-        public int PrimaryBlockID { get; set; }
+        public short PrimaryBlockID { get; set; }
         /// <summary>The Block ID of the collision block.</summary>
-        public int BlockID
+        public short BlockID
         {
             get => PrimaryBlockID;
             set => PrimaryBlockID = value;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CountTextObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CountTextObject.cs
@@ -1,4 +1,5 @@
 ﻿using GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.Interfaces;
+using GDEdit.Utilities.Enumerations.GeometryDash;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,12 +12,12 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
     public class CountTextObject : SpecialObject, IHasPrimaryItemID
     {
         /// <summary>The object ID of the count text block.</summary>
-        public new int ObjectID => (int)Enumerations.GeometryDash.SpecialObjectType.CountTextObject;
+        public new short ObjectID => (short)(int)SpecialObjectType.CountTextObject;
 
         /// <summary>The Item ID the count text object displays.</summary>
-        public int PrimaryItemID { get; set; }
+        public short PrimaryItemID { get; set; }
         /// <summary>The Item ID the count text object displays.</summary>
-        public int ItemID
+        public short ItemID
         {
             get => PrimaryItemID;
             set => PrimaryItemID = value;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/BlackOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/BlackOrb.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
     public class BlackOrb : Orb
     {
         /// <summary>The object ID of the black orb.</summary>
-        public override int ObjectID => (int)OrbType.BlackOrb;
+        public override short ObjectID => (short)(int)OrbType.BlackOrb;
 
         /// <summary>Initializes a new instance of the <seealso cref="BlackOrb"/> class.</summary>
         public BlackOrb() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/BlueOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/BlueOrb.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
     public class BlueOrb : Orb
     {
         /// <summary>The object ID of the blue orb.</summary>
-        public override int ObjectID => (int)OrbType.BlueOrb;
+        public override short ObjectID => (short)(int)OrbType.BlueOrb;
 
         /// <summary>Initializes a new instance of the <seealso cref="BlueOrb"/> class.</summary>
         public BlueOrb() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/GreenDashOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/GreenDashOrb.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
     public class GreenDashOrb : Orb
     {
         /// <summary>The object ID of the green dash orb.</summary>
-        public override int ObjectID => (int)OrbType.GreenDashOrb;
+        public override short ObjectID => (short)(int)OrbType.GreenDashOrb;
 
         /// <summary>Initializes a new instance of the <seealso cref="GreenDashOrb"/> class.</summary>
         public GreenDashOrb() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/GreenOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/GreenOrb.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
     public class GreenOrb : Orb
     {
         /// <summary>The object ID of the green orb.</summary>
-        public override int ObjectID => (int)OrbType.GreenOrb;
+        public override short ObjectID => (short)(int)OrbType.GreenOrb;
 
         /// <summary>Initializes a new instance of the <seealso cref="GreenOrb"/> class.</summary>
         public GreenOrb() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/MagentaDashOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/MagentaDashOrb.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
     public class MagentaDashOrb : Orb
     {
         /// <summary>The object ID of the magenta dash orb.</summary>
-        public override int ObjectID => (int)OrbType.MagentaDashOrb;
+        public override short ObjectID => (short)(int)OrbType.MagentaDashOrb;
 
         /// <summary>Initializes a new instance of the <seealso cref="MagentaDashOrb"/> class.</summary>
         public MagentaDashOrb() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/MagentaOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/MagentaOrb.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
     public class MagentaOrb : Orb
     {
         /// <summary>The object ID of the magenta orb.</summary>
-        public override int ObjectID => (int)OrbType.MagentaOrb;
+        public override short ObjectID => (short)(int)OrbType.MagentaOrb;
 
         /// <summary>Initializes a new instance of the <seealso cref="MagentaOrb"/> class.</summary>
         public MagentaOrb() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/Orb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/Orb.cs
@@ -14,11 +14,15 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
     public abstract class Orb : SpecialObject
     {
         /// <summary>The object ID of the orb.</summary>
-        public new abstract int ObjectID { get; }
+        public new abstract short ObjectID { get; }
 
         /// <summary>Represents the Multi Activate property of the orb.</summary>
         [ObjectStringMappable(ObjectParameter.MultiActivate)]
-        public bool MultiActivate { get; set; }
+        public bool MultiActivate
+		{
+			get => SpecialObjectBools[0];
+			set => SpecialObjectBools[0] = value;
+		}
 
         /// <summary>Initializes a new instance of the <seealso cref="Orb"/> class.</summary>
         public Orb() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/RedOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/RedOrb.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
     public class RedOrb : Orb
     {
         /// <summary>The object ID of the red orb.</summary>
-        public override int ObjectID => (int)OrbType.RedOrb;
+        public override short ObjectID => (short)(int)OrbType.RedOrb;
 
         /// <summary>Initializes a new instance of the <seealso cref="RedOrb"/> class.</summary>
         public RedOrb() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/TriggerOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/TriggerOrb.cs
@@ -15,14 +15,18 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
     public class TriggerOrb : Orb, IHasTargetGroupID
     {
         /// <summary>The object ID of the trigger orb.</summary>
-        public override int ObjectID => (int)OrbType.TriggerOrb;
+        public override short ObjectID => (short)(int)OrbType.TriggerOrb;
 
         /// <summary>Represents the Target Group ID of the trigger orb.</summary>
         [ObjectStringMappable(ObjectParameter.TargetGroupID)]
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>Represents the Activate Group property of the trigger orb.</summary>
         [ObjectStringMappable(ObjectParameter.ActivateGroup)]
-        public bool ActivateGroup { get; set; }
+        public bool ActivateGroup
+		{
+			get => SpecialObjectBools[1];
+			set => SpecialObjectBools[1] = value;
+		}
 
         /// <summary>Initializes a new instance of the <seealso cref="TriggerOrb"/> class.</summary>
         public TriggerOrb() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/YellowOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/YellowOrb.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
     public class YellowOrb : Orb
     {
         /// <summary>The object ID of the yellow orb.</summary>
-        public override int ObjectID => (int)OrbType.YellowOrb;
+        public override short ObjectID => (short)(int)OrbType.YellowOrb;
 
         /// <summary>Initializes a new instance of the <seealso cref="YellowOrb"/> class.</summary>
         public YellowOrb() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Pads/BluePad.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Pads/BluePad.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Pads
     public class BluePad : Pad
     {
         /// <summary>The object ID of the blue pad.</summary>
-        public override int ObjectID => (int)PadType.BluePad;
+        public override short ObjectID => (short)(int)PadType.BluePad;
 
         /// <summary>Initializes a new instance of the <seealso cref="BluePad"/> class.</summary>
         public BluePad() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Pads/MagentaPad.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Pads/MagentaPad.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Pads
     public class MagentaPad : Pad
     {
         /// <summary>The object ID of the magenta pad.</summary>
-        public override int ObjectID => (int)PadType.MagentaPad;
+        public override short ObjectID => (short)(int)PadType.MagentaPad;
 
         /// <summary>Initializes a new instance of the <seealso cref="MagentaPad"/> class.</summary>
         public MagentaPad() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Pads/Pad.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Pads/Pad.cs
@@ -14,7 +14,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Pads
     public abstract class Pad : SpecialObject
     {
         /// <summary>The object ID of the pad.</summary>
-        public new abstract int ObjectID { get; }
+        public new abstract short ObjectID { get; }
 
         /// <summary>Initializes a new instance of the <seealso cref="Pad"/> class.</summary>
         public Pad() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Pads/RedPad.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Pads/RedPad.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Pads
     public class RedPad : Pad
     {
         /// <summary>The object ID of the red pad.</summary>
-        public override int ObjectID => (int)PadType.RedPad;
+        public override short ObjectID => (short)(int)PadType.RedPad;
 
         /// <summary>Initializes a new instance of the <seealso cref="RedPad"/> class.</summary>
         public RedPad() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Pads/YellowPad.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Pads/YellowPad.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Pads
     public class YellowPad : Pad
     {
         /// <summary>The object ID of the yellow pad.</summary>
-        public override int ObjectID => (int)PadType.YellowPad;
+        public override short ObjectID => (short)(int)PadType.YellowPad;
 
         /// <summary>Initializes a new instance of the <seealso cref="YellowPad"/> class.</summary>
         public YellowPad() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PickupItem.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PickupItem.cs
@@ -14,7 +14,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
     public class PickupItem : SpecialObject, IHasTargetGroupID
     {
         protected override int[] ValidObjectIDs => ObjectLists.PickupItemList;
-        protected override string SpecialObjectType => "pickup item";
+        protected override string SpecialObjectTypeName => "pickup item";
 
         /// <summary>Represents the Pickup Mode property of the pickup item.</summary>
         [ObjectStringMappable(ObjectParameter.PickupMode)]

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PickupItem.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PickupItem.cs
@@ -21,22 +21,30 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
         public PickupItemPickupMode PickupMode { get; set; }
         /// <summary>Represents the Count property of the pickup item.</summary>
         [ObjectStringMappable(ObjectParameter.Count)]
-        public int Count { get; set; }
+        public short Count { get; set; }
         /// <summary>Represents the Subtract Count property of the pickup item.</summary>
         [ObjectStringMappable(ObjectParameter.SubtractCount)]
-        public bool SubtractCount { get; set; }
+        public bool SubtractCount
+		{
+			get => SpecialObjectBools[0];
+			set => SpecialObjectBools[0] = value;
+		}
         /// <summary>Represents the Target Group ID property of the pickup item.</summary>
         [ObjectStringMappable(ObjectParameter.TargetGroupID)]
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>Represents the Enable Group property of the pickup item.</summary>
         [ObjectStringMappable(ObjectParameter.ActivateGroup)]
-        public bool EnableGroup { get; set; }
+        public bool EnableGroup
+		{
+			get => SpecialObjectBools[1];
+			set => SpecialObjectBools[1] = value;
+		}
 
         /// <summary>Initializes a new instance of the <seealso cref="PickupItem"/> class.</summary>
         /// <param name="objectID">The object ID of the pickup item.</param>
         /// <param name="x">The X location of the object.</param>
         /// <param name="y">The Y location of the object.</param>
-        public PickupItem(int objectID, double x, double y)
+        public PickupItem(short objectID, double x, double y)
             : base(objectID, x, y) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueDualPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueDualPortal.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class BlueDualPortal : Portal
     {
         /// <summary>The object ID of the blue dual portal.</summary>
-        public override int ObjectID => (int)PortalType.BlueDual;
+        public override short ObjectID => (short)(int)PortalType.BlueDual;
 
         /// <summary>Initializes a new instance of the <seealso cref="BlueDualPortal"/> class.</summary>
         public BlueDualPortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueGravityPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueGravityPortal.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class BlueGravityPortal : Portal
     {
         /// <summary>The object ID of the blue gravity portal.</summary>
-        public override int ObjectID => (int)PortalType.BlueGravity;
+        public override short ObjectID => (short)(int)PortalType.BlueGravity;
 
         /// <summary>Initializes a new instance of the <seealso cref="BlueGravityPortal"/> class.</summary>
         public BlueGravityPortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueMirrorPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueMirrorPortal.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class BlueMirrorPortal : Portal
     {
         /// <summary>The object ID of the blue mirror portal.</summary>
-        public override int ObjectID => (int)PortalType.BlueMirror;
+        public override short ObjectID => (short)(int)PortalType.BlueMirror;
 
         /// <summary>Initializes a new instance of the <seealso cref="BlueMirrorPortal"/> class.</summary>
         public BlueMirrorPortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueTeleportationPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueTeleportationPortal.cs
@@ -26,7 +26,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
         }
 
         /// <summary>The object ID of the blue teleportation portal.</summary>
-        public override int ObjectID => (int)PortalType.BlueTeleportation;
+        public override short ObjectID => (short)(int)PortalType.BlueTeleportation;
 
         /// <summary>The distance of the Y location between the yellow and this teleportation portals.</summary>
         [ObjectStringMappable(ObjectParameter.YellowTeleportationPortalDistance)]

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/BallPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/BallPortal.cs
@@ -14,13 +14,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class BallPortal : GamemodePortal, IHasCheckedProperty
     {
         /// <summary>The object ID of the ball portal.</summary>
-        public override int ObjectID => (int)PortalType.Ball;
+        public override short ObjectID => (short)(int)PortalType.Ball;
         /// <summary>The gamemode the gamemode portal transforms the player into.</summary>
         public override Gamemode Gamemode => Gamemode.Ball;
 
         /// <summary>The checked property of the ball portal that determines whether the borders of the player's gamemode will be shown or not.</summary>
         [ObjectStringMappable(ObjectParameter.PortalChecked)]
-        public bool Checked { get; set; }
+        public bool Checked
+		{
+			get => SpecialObjectBools[0];
+			set => SpecialObjectBools[0] = value;
+		}
 
         /// <summary>Initializes a new instance of the <seealso cref="BallPortal"/> class.</summary>
         public BallPortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/CubePortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/CubePortal.cs
@@ -13,7 +13,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class CubePortal : GamemodePortal
     {
         /// <summary>The object ID of the cube portal.</summary>
-        public override int ObjectID => (int)PortalType.Cube;
+        public override short ObjectID => (short)(int)PortalType.Cube;
         /// <summary>The gamemode the gamemode portal transforms the player into.</summary>
         public override Gamemode Gamemode => Gamemode.Cube;
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/RobotPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/RobotPortal.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class RobotPortal : GamemodePortal
     {
         /// <summary>The object ID of the robot portal.</summary>
-        public override int ObjectID => (int)PortalType.Robot;
+        public override short ObjectID => (short)(int)PortalType.Robot;
         /// <summary>The gamemode the gamemode portal transforms the player into.</summary>
         public override Gamemode Gamemode => Gamemode.Robot;
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/ShipPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/ShipPortal.cs
@@ -14,13 +14,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class ShipPortal : GamemodePortal, IHasCheckedProperty
     {
         /// <summary>The object ID of the ship portal.</summary>
-        public override int ObjectID => (int)PortalType.Ship;
+        public override short ObjectID => (short)(int)PortalType.Ship;
         /// <summary>The gamemode the gamemode portal transforms the player into.</summary>
         public override Gamemode Gamemode => Gamemode.Ship;
 
         /// <summary>The checked property of the ship portal that determines whether the borders of the player's gamemode will be shown or not.</summary>
         [ObjectStringMappable(ObjectParameter.PortalChecked)]
-        public bool Checked { get; set; }
+        public bool Checked
+		{
+			get => SpecialObjectBools[0];
+			set => SpecialObjectBools[0] = value;
+		}
 
         /// <summary>Initializes a new instance of the <seealso cref="ShipPortal"/> class.</summary>
         public ShipPortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/SpiderPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/SpiderPortal.cs
@@ -14,13 +14,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class SpiderPortal : GamemodePortal, IHasCheckedProperty
     {
         /// <summary>The object ID of the spider portal.</summary>
-        public override int ObjectID => (int)PortalType.Spider;
+        public override short ObjectID => (short)(int)PortalType.Spider;
         /// <summary>The gamemode the gamemode portal transforms the player into.</summary>
         public override Gamemode Gamemode => Gamemode.Spider;
 
         /// <summary>The checked property of the spider portal that determines whether the borders of the player's gamemode will be shown or not.</summary>
         [ObjectStringMappable(ObjectParameter.PortalChecked)]
-        public bool Checked { get; set; }
+        public bool Checked
+		{
+			get => SpecialObjectBools[0];
+			set => SpecialObjectBools[0] = value;
+		}
 
         /// <summary>Initializes a new instance of the <seealso cref="SpiderPortal"/> class.</summary>
         public SpiderPortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/UFOPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/UFOPortal.cs
@@ -14,13 +14,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class UFOPortal : GamemodePortal, IHasCheckedProperty
     {
         /// <summary>The object ID of the UFO portal.</summary>
-        public override int ObjectID => (int)PortalType.UFO;
+        public override short ObjectID => (short)(int)PortalType.UFO;
         /// <summary>The gamemode the gamemode portal transforms the player into.</summary>
         public override Gamemode Gamemode => Gamemode.UFO;
 
         /// <summary>The checked property of the UFO portal that determines whether the borders of the player's gamemode will be shown or not.</summary>
         [ObjectStringMappable(ObjectParameter.PortalChecked)]
-        public bool Checked { get; set; }
+        public bool Checked
+		{
+			get => SpecialObjectBools[0];
+			set => SpecialObjectBools[0] = value;
+		}
 
         /// <summary>Initializes a new instance of the <seealso cref="UFOPortal"/> class.</summary>
         public UFOPortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/WavePortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/WavePortal.cs
@@ -14,13 +14,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class WavePortal : GamemodePortal, IHasCheckedProperty
     {
         /// <summary>The object ID of the wave portal.</summary>
-        public override int ObjectID => (int)PortalType.Wave;
+        public override short ObjectID => (short)(int)PortalType.Wave;
         /// <summary>The gamemode the gamemode portal transforms the player into.</summary>
         public override Gamemode Gamemode => Gamemode.Wave;
 
         /// <summary>The checked property of the wave portal that determines whether the borders of the player's gamemode will be shown or not.</summary>
         [ObjectStringMappable(ObjectParameter.PortalChecked)]
-        public bool Checked { get; set; }
+        public bool Checked
+		{
+			get => SpecialObjectBools[0];
+			set => SpecialObjectBools[0] = value;
+		}
 
         /// <summary>Initializes a new instance of the <seealso cref="WavePortal"/> class.</summary>
         public WavePortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GreenSizePortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GreenSizePortal.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class GreenSizePortal : Portal
     {
         /// <summary>The object ID of the green size portal.</summary>
-        public override int ObjectID => (int)PortalType.GreenSize;
+        public override short ObjectID => (short)(int)PortalType.GreenSize;
 
         /// <summary>Initializes a new instance of the <seealso cref="GreenSizePortal"/> class.</summary>
         public GreenSizePortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/MagentaSizePortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/MagentaSizePortal.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class MagentaSizePortal : Portal
     {
         /// <summary>The object ID of the magenta size portal.</summary>
-        public override int ObjectID => (int)PortalType.MagentaSize;
+        public override short ObjectID => (short)(int)PortalType.MagentaSize;
 
         /// <summary>Initializes a new instance of the <seealso cref="MagentaSizePortal"/> class.</summary>
         public MagentaSizePortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/Portal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/Portal.cs
@@ -10,7 +10,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public abstract class Portal : SpecialObject
     {
         /// <summary>The object ID of the portal.</summary>
-        public new abstract int ObjectID { get; }
+        public new abstract short ObjectID { get; }
 
         /// <summary>Initializes a new instance of the <seealso cref="Portal"/> class.</summary>
         public Portal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/FastSpeedPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/FastSpeedPortal.cs
@@ -14,7 +14,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class FastSpeedPortal : SpeedPortal, IHasCheckedProperty
     {
         /// <summary>The object ID of the fast speed portal.</summary>
-        public override int ObjectID => (int)PortalType.FastSpeed;
+        public override short ObjectID => (short)(int)PortalType.FastSpeed;
 
         /// <summary>The speed this speed portal sets.</summary>
         public override Speed Speed => Speed.Fast;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/FasterSpeedPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/FasterSpeedPortal.cs
@@ -14,7 +14,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class FasterSpeedPortal : SpeedPortal, IHasCheckedProperty
     {
         /// <summary>The object ID of the faster speed portal.</summary>
-        public override int ObjectID => (int)PortalType.FasterSpeed;
+        public override short ObjectID => (short)(int)PortalType.FasterSpeed;
 
         /// <summary>The speed this speed portal sets.</summary>
         public override Speed Speed => Speed.Faster;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/FastestSpeedPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/FastestSpeedPortal.cs
@@ -14,7 +14,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class FastestSpeedPortal : SpeedPortal, IHasCheckedProperty
     {
         /// <summary>The object ID of the fastest speed portal.</summary>
-        public override int ObjectID => (int)PortalType.FasterSpeed;
+        public override short ObjectID => (short)(int)PortalType.FasterSpeed;
 
         /// <summary>The speed this speed portal sets.</summary>
         public override Speed Speed => Speed.Faster;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/NormalSpeedPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/NormalSpeedPortal.cs
@@ -14,7 +14,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class NormalSpeedPortal : SpeedPortal, IHasCheckedProperty
     {
         /// <summary>The object ID of the normal speed portal.</summary>
-        public override int ObjectID => (int)PortalType.NormalSpeed;
+        public override short ObjectID => (short)(int)PortalType.NormalSpeed;
 
         /// <summary>The speed this speed portal sets.</summary>
         public override Speed Speed => Speed.Normal;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/SlowSpeedPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/SlowSpeedPortal.cs
@@ -14,7 +14,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class SlowSpeedPortal : SpeedPortal, IHasCheckedProperty
     {
         /// <summary>The object ID of the slow speed portal.</summary>
-        public override int ObjectID => (int)PortalType.SlowSpeed;
+        public override short ObjectID => (short)(int)PortalType.SlowSpeed;
 
         /// <summary>The speed this speed portal sets.</summary>
         public override Speed Speed => Speed.Slow;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/SpeedPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/SpeedPortal.cs
@@ -17,7 +17,11 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
 
         /// <summary>The checked property of the speed portal that determines whether the speed portal will be taken into account when converting X position to time.</summary>
         [ObjectStringMappable(ObjectParameter.PortalChecked)]
-        public bool Checked { get; set; }
+        public bool Checked
+		{
+			get => SpecialObjectBools[0];
+			set => SpecialObjectBools[0] = value;
+		}
 
         /// <summary>Initializes a new instance of the <seealso cref="SpeedPortal"/> class.</summary>
         public SpeedPortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowDualPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowDualPortal.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class YellowDualPortal : Portal
     {
         /// <summary>The object ID of the yellow dual portal.</summary>
-        public override int ObjectID => (int)PortalType.YellowDual;
+        public override short ObjectID => (short)(int)PortalType.YellowDual;
 
         /// <summary>Initializes a new instance of the <seealso cref="YellowDualPortal"/> class.</summary>
         public YellowDualPortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowGravityPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowGravityPortal.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class YellowGravityPortal : Portal
     {
         /// <summary>The object ID of the yellow gravity portal.</summary>
-        public override int ObjectID => (int)PortalType.YellowGravity;
+        public override short ObjectID => (short)(int)PortalType.YellowGravity;
 
         /// <summary>Initializes a new instance of the <seealso cref="YellowGravityPortal"/> class.</summary>
         public YellowGravityPortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowMirrorPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowMirrorPortal.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
     public class YellowMirrorPortal : Portal
     {
         /// <summary>The object ID of the yellow mirror portal.</summary>
-        public override int ObjectID => (int)PortalType.YellowMirror;
+        public override short ObjectID => (short)(int)PortalType.YellowMirror;
 
         /// <summary>Initializes a new instance of the <seealso cref="YellowMirrorPortal"/> class.</summary>
         public YellowMirrorPortal() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowTeleportationPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowTeleportationPortal.cs
@@ -19,7 +19,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
         public readonly BlueTeleportationPortal LinkedTeleportationPortal;
 
         /// <summary>The object ID of the yellow teleportation portal.</summary>
-        public override int ObjectID => (int)PortalType.YellowTeleportation;
+        public override short ObjectID => (short)(int)PortalType.YellowTeleportation;
 
         /// <summary>Initializes a new instance of the <seealso cref="YellowTeleportationPortal"/> class.</summary>
         public YellowTeleportationPortal(BlueTeleportationPortal p)

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
@@ -14,7 +14,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
     public class PulsatingObject : SpecialObject
     {
         protected override int[] ValidObjectIDs => ObjectLists.PulsatingObjectList;
-        protected override string SpecialObjectType => "pulsating object";
+        protected override string SpecialObjectTypeName => "pulsating object";
 
         /// <summary>The animation speed of the pulsating object as a ratio.</summary>
         [ObjectStringMappable(ObjectParameter.AnimationSpeed)]

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
@@ -21,13 +21,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
         public float AnimationSpeed { get; set; }
         /// <summary>The Randomize Start property of the pulsating object.</summary>
         [ObjectStringMappable(ObjectParameter.RandomizeStart)]
-        public bool RandomizeStart { get; set; }
+        public bool RandomizeStart
+		{
+			get => SpecialObjectBools[0];
+			set => SpecialObjectBools[0] = value;
+		}
 
         /// <summary>Initializes a new instance of the <seealso cref="PulsatingObject"/> class.</summary>
         /// <param name="objectID">The object ID of the pulsating object.</param>
         /// <param name="x">The X location of the object.</param>
         /// <param name="y">The Y location of the object.</param>
-        public PulsatingObject(int objectID, double x, double y)
+        public PulsatingObject(short objectID, double x, double y)
             : base(objectID, x, y) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/RotatingObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/RotatingObject.cs
@@ -17,13 +17,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
 
         /// <summary>Represents the Disable Rotation property of the rotating object.</summary>
         [ObjectStringMappable(ObjectParameter.DisableRotation)]
-        public bool DisableRotation;
+        public bool DisableRotation
+		{
+			get => SpecialObjectBools[0];
+			set => SpecialObjectBools[0] = value;
+		}
 
         /// <summary>Initializes a new instance of the <seealso cref="RotatingObject"/> class.</summary>
         /// <param name="objectID">The object ID of the rotating object.</param>
         /// <param name="x">The X location of the object.</param>
         /// <param name="y">The Y location of the object.</param>
-        public RotatingObject(int objectID, double x, double y)
+        public RotatingObject(short objectID, double x, double y)
             : base(objectID, x, y) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/RotatingObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/RotatingObject.cs
@@ -13,7 +13,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
     public class RotatingObject : SpecialObject
     {
         protected override int[] ValidObjectIDs => ObjectLists.RotatingObjectList;
-        protected override string SpecialObjectType => "rotating object";
+        protected override string SpecialObjectTypeName => "rotating object";
 
         /// <summary>Represents the Disable Rotation property of the rotating object.</summary>
         [ObjectStringMappable(ObjectParameter.DisableRotation)]

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialBlocks/DSpecialBlock.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialBlocks/DSpecialBlock.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Spec
     public class DSpecialBlock : SpecialBlock
     {
         /// <summary>The object ID of the D special block.</summary>
-        public override int ObjectID => (int)SpecialBlockType.D;
+        public override short ObjectID => (short)(int)SpecialBlockType.D;
 
         /// <summary>Initializes a new instance of the <seealso cref="DSpecialBlock"/> class.</summary>
         public DSpecialBlock() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialBlocks/HSpecialBlock.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialBlocks/HSpecialBlock.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Spec
     public class HSpecialBlock : SpecialBlock
     {
         /// <summary>The object ID of the H special block.</summary>
-        public override int ObjectID => (int)SpecialBlockType.H;
+        public override short ObjectID => (short)(int)SpecialBlockType.H;
 
         /// <summary>Initializes a new instance of the <seealso cref="HSpecialBlock"/> class.</summary>
         public HSpecialBlock() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialBlocks/JSpecialBlock.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialBlocks/JSpecialBlock.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Spec
     public class JSpecialBlock : SpecialBlock
     {
         /// <summary>The object ID of the J special block.</summary>
-        public override int ObjectID => (int)SpecialBlockType.J;
+        public override short ObjectID => (short)(int)SpecialBlockType.J;
 
         /// <summary>Initializes a new instance of the <seealso cref="JSpecialBlock"/> class.</summary>
         public JSpecialBlock() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialBlocks/SSpecialBlock.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialBlocks/SSpecialBlock.cs
@@ -11,7 +11,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Spec
     public class SSpecialBlock : SpecialBlock
     {
         /// <summary>The object ID of the S special block.</summary>
-        public override int ObjectID => (int)SpecialBlockType.S;
+        public override short ObjectID => (short)(int)SpecialBlockType.S;
 
         /// <summary>Initializes a new instance of the <seealso cref="SSpecialBlock"/> class.</summary>
         public SSpecialBlock() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialBlocks/SpecialBlock.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialBlocks/SpecialBlock.cs
@@ -10,7 +10,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Spec
     public abstract class SpecialBlock : SpecialObject
     {
         /// <summary>The object ID of the special block.</summary>
-        public new abstract int ObjectID { get; }
+        public new abstract short ObjectID { get; }
 
         /// <summary>Initializes a new instance of the <seealso cref="SpecialBlock"/> class.</summary>
         public SpecialBlock() : base() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
         /// <summary>The valid object IDs of the special object. Only override if the class does not represent a single object.</summary>
         protected virtual int[] ValidObjectIDs => null;
         /// <summary>The name as a string of the special object. Only override if the class does not represent a single object.</summary>
-        protected virtual string SpecialObjectType => "special object";
+        protected virtual string SpecialObjectTypeName => "special object";
 
         /// <summary>Initializes a new instance of the <seealso cref="SpecialObject"/> class.</summary>
         public SpecialObject() { }
@@ -28,7 +28,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
         {
             // Since this constructor must be only used by general object classes that may have different object IDs, assume the property is overriden
             if (!ValidObjectIDs.Contains(objectID))
-                throw new InvalidCastException($"This object ID does not represent a valid {SpecialObjectType}.");
+                throw new InvalidCastException($"This object ID does not represent a valid {SpecialObjectTypeName}.");
         }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
@@ -9,6 +9,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
     /// <summary>Represents a special object.</summary>
     public abstract class SpecialObject : GeneralObject
     {
+        /// <summary>The <seealso cref="bool"/>s of the special objects.</summary>
+		protected BitArray8 SpecialObjectBools = new BitArray8();
         /// <summary>The valid object IDs of the special object. Only override if the class does not represent a single object.</summary>
         protected virtual int[] ValidObjectIDs => null;
         /// <summary>The name as a string of the special object. Only override if the class does not represent a single object.</summary>
@@ -20,7 +22,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
         /// <param name="objectID">The object ID of the rotating object.</param>
         /// <param name="x">The X location of the object.</param>
         /// <param name="y">The Y location of the object.</param>
-        public SpecialObject(int objectID, double x, double y)
+        public SpecialObject(short objectID, double x, double y)
             : base(objectID, x, y)
         {
             // Since this constructor must be only used by general object classes that may have different object IDs, assume the property is overriden

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GDEdit.Utilities.Objects.General;
 
 namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
 {

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/TextObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/TextObject.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GDEdit.Utilities.Objects.General;
 
 namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
 {

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/TextObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/TextObject.cs
@@ -14,7 +14,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
     public class TextObject : SpecialObject
     {
         /// <summary>The object ID of the text object.</summary>
-        public new int ObjectID => (int)Enumerations.GeometryDash.SpecialObjectType.TextObject;
+        public new short ObjectID => (int)SpecialObjectType.TextObject;
 
         /// <summary>Represents the Text property of the text object encoded in base 64.</summary>
         [ObjectStringMappable(ObjectParameter.TextObjectText)]

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/TextObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/TextObject.cs
@@ -1,4 +1,5 @@
 ﻿using GDEdit.Utilities.Attributes;
+using GDEdit.Utilities.Enumerations.GeometryDash;
 using GDEdit.Utilities.Enumerations.GeometryDash.GamesaveValues;
 using GDEdit.Utilities.Information.GeometryDash;
 using GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.Interfaces;
@@ -7,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using GDEdit.Utilities.Objects.General;
 
 namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
 {
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
     public class TextObject : SpecialObject
     {
         /// <summary>The object ID of the text object.</summary>
-        public new short ObjectID => (int)SpecialObjectType.TextObject;
+        public new short ObjectID => (short)(int)SpecialObjectType.TextObject;
 
         /// <summary>Represents the Text property of the text object encoded in base 64.</summary>
         [ObjectStringMappable(ObjectParameter.TextObjectText)]

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
@@ -17,7 +17,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The Opacity property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.Opacity)]
         public float Opacity { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Alpha trigger.</summary>
     public class AlphaTrigger : Trigger, IHasDuration, IHasTargetGroupID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Alpha;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Alpha;
 
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
@@ -28,7 +28,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="duration">The duration of the trigger.</param>
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
         /// <param name="opacity">The Opacity property of the trigger.</param>
-        public AlphaTrigger(float duration, int targetGroupID, float opacity)
+        public AlphaTrigger(float duration, short targetGroupID, float opacity)
         {
             Duration = duration;
             TargetGroupID = targetGroupID;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
@@ -15,10 +15,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Animate;
         
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The Animation ID property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.AnimationID)]
-        public int AnimationID { get; set; }
+        public byte AnimationID { get; set; }
 
         /// <summary>Initializes a new instance of the <seealso cref="AnimateTrigger"/> class.</summary>
         public AnimateTrigger() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
@@ -25,7 +25,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <summary>Initializes a new instance of the <seealso cref="AnimateTrigger"/> class.</summary>
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
         /// <param name="animationID">The Animation ID property of the trigger.</summary>
-        public AnimateTrigger(int targetGroupID, int animationID)
+        public AnimateTrigger(short targetGroupID, byte animationID)
         {
             TargetGroupID = targetGroupID;
             AnimationID = animationID;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents an Animate trigger.</summary>
     public class AnimateTrigger : Trigger, IHasTargetGroupID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Animate;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Animate;
         
         /// <summary>The target Group ID of the trigger.</summary>
         public short TargetGroupID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
@@ -43,7 +43,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
         /// <param name="activateGroup">The Activate Group of the trigger.</param>
         /// <param name="triggerOnExit">The Trigger On Exit of the trigger.</param>
-        public CollisionTrigger(int primaryBlockID, int secondaryBlockID, int targetGroupID, bool activateGroup = false, bool triggerOnExit = false)
+        public CollisionTrigger(short primaryBlockID, short secondaryBlockID, short targetGroupID, bool activateGroup = false, bool triggerOnExit = false)
         {
             PrimaryBlockID = primaryBlockID;
             SecondaryBlockID = secondaryBlockID;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Collision trigger.</summary>
     public class CollisionTrigger : Trigger, IHasTargetGroupID, IHasPrimaryBlockID, IHasSecondaryBlockID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Collision;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Collision;
         
         /// <summary>The target Group ID of the trigger.</summary>
         public short TargetGroupID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
@@ -15,17 +15,25 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Collision;
         
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The primary Block ID of the trigger.</summary>
-        public int PrimaryBlockID { get; set; }
+        public short PrimaryBlockID { get; set; }
         /// <summary>The secondary Block ID of the trigger.</summary>
-        public int SecondaryBlockID { get; set; }
+        public short SecondaryBlockID { get; set; }
         /// <summary>The Activate Group property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.ActivateGroup)]
-        public bool ActivateGroup { get; set; }
+        public bool ActivateGroup
+        {
+            get => TriggerBools[3];
+            set => TriggerBools[3] = value;
+        }
         /// <summary>The Trigger On Exit property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.TriggerOnExit)]
-        public bool TriggerOnExit { get; set; }
+        public bool TriggerOnExit
+        {
+            get => TriggerBools[4];
+            set => TriggerBools[4] = value;
+        }
 
         /// <summary>Initializes a new instance of the <seealso cref="CollisionTrigger"/> class.</summary>
         public CollisionTrigger() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
@@ -16,31 +16,43 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Color;
         
         /// <summary>The target Color ID of the trigger.</summary>
-        public int TargetColorID { get; set; }
+        public short TargetColorID { get; set; }
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;
         /// <summary>The red part of the color.</summary>
-        public int Red { get; set; }
+        public byte Red { get; set; }
         /// <summary>The green part of the color.</summary>
-        public int Green { get; set; }
+        public byte Green { get; set; }
         /// <summary>The blue part of the color.</summary>
-        public int Blue { get; set; }
+        public byte Blue { get; set; }
         /// <summary>The Opacity property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.Opacity)]
         public float Opacity { get; set; } = 1;
-        /// <summary>The Blending property of the trigger.</summary>
-        [ObjectStringMappable(ObjectParameter.Blending)]
-        public bool Blending { get; set; }
         // IMPORTANT: The Player 1 and Player 2 properties are ignored because the Copied Color ID serves that purpose well
         /// <summary>The copied Color ID of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.CopiedColorID)]
-        public int CopiedColorID { get; set; }
+        public short CopiedColorID { get; set; }
+        /// <summary>The Blending property of the trigger.</summary>
+        [ObjectStringMappable(ObjectParameter.Blending)]
+        public bool Blending
+        {
+            get => TriggerBools[3];
+            set => TriggerBools[3] = value;
+        }
         /// <summary>The Copy Opacity property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.CopyOpacity)]
-        public bool CopyOpacity { get; set; }
+        public bool CopyOpacity
+        {
+            get => TriggerBools[4];
+            set => TriggerBools[4] = value;
+        }
         /// <summary>The Tint Ground property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.TintGround)]
-        public bool TintGround { get; set; }
+        public bool TintGround
+        {
+            get => TriggerBools[5];
+            set => TriggerBools[5] = value;
+        }
         /// <summary>The HSV of the trigger (as a string for the gamesave).</summary>
         [ObjectStringMappable(ObjectParameter.CopiedColorHSVValues)]
         public string HSV => HSVAdjustment.ToString();

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
@@ -64,7 +64,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public ColorTrigger() { }
         /// <summary>Initializes a new instance of the <seealso cref="ColorTrigger"/> class.</summary>
         /// <param name="targetID">The target ID of the trigger.</param>
-        public ColorTrigger(int targetID)
+        public ColorTrigger(short targetID)
         {
             TargetColorID = targetID;
         }
@@ -73,7 +73,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="targetID">The target ID of the trigger.</param>
         /// <param name="copyOpacity">The Copy Opacity property of the trigger.</param>
         /// <param name="tintGround">The Tint Ground property of the trigger.</param>
-        public ColorTrigger(float duration, int targetID, bool copyOpacity = false, bool tintGround = false)
+        public ColorTrigger(float duration, short targetID, bool copyOpacity = false, bool tintGround = false)
             : this(targetID)
         {
             Duration = duration;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
@@ -13,7 +13,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Color trigger.</summary>
     public class ColorTrigger : Trigger, IHasTargetColorID, IHasColor, IHasDuration
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Color;
+        public override short ObjectID => (short)(short)(int)Enumerations.GeometryDash.TriggerType.Color;
         
         /// <summary>The target Color ID of the trigger.</summary>
         public short TargetColorID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/BGColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/BGColorTrigger.cs
@@ -10,10 +10,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
     /// <summary>Represents a BG Color trigger.</summary>
     public class BGColorTrigger : ColorTrigger
     {
-        public override int ObjectID => (int)TriggerType.BG;
+        public override short ObjectID => (short)(int)TriggerType.BG;
         
         /// <summary>The target Color ID of the trigger.</summary>
-        public new int TargetColorID => (int)SpecialColorID.BG;
+        public new short TargetColorID => (short)(int)SpecialColorID.BG;
 
         /// <summary>Initializes a new instance of the <seealso cref="BGColorTrigger"/> class.</summary>
         public BGColorTrigger() { }
@@ -21,6 +21,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
         /// <param name="duration">The duration of the trigger.</param>
         /// <param name="tintGround">The Tint Ground property of the trigger.</param>
         public BGColorTrigger(float duration, bool tintGround = false)
-            : base(duration, (int)SpecialColorID.BG, false, tintGround) { }
+            : base(duration, (short)(int)SpecialColorID.BG, false, tintGround) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/Color1ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/Color1ColorTrigger.cs
@@ -10,10 +10,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
     /// <summary>Represents a Color 1 Color trigger.</summary>
     public class Color1ColorTrigger : ColorTrigger
     {
-        public override int ObjectID => (int)TriggerType.Color1;
+        public override short ObjectID => (short)(int)TriggerType.Color1;
         
         /// <summary>The target Color ID of the trigger.</summary>
-        public new int TargetColorID => 1;
+        public new short TargetColorID => 1;
 
         /// <summary>Initializes a new instance of the <seealso cref="Color1ColorTrigger"/> class.</summary>
         public Color1ColorTrigger() { }
@@ -22,6 +22,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
         /// <param name="copyOpacity">The Copy Opacity property of the trigger.</param>
         /// <param name="tintGround">The Tint Ground property of the trigger.</param>
         public Color1ColorTrigger(float duration, bool copyOpacity = false, bool tintGround = false)
-            : base(duration, (int)SpecialColorID.BG, copyOpacity, tintGround) { }
+            : base(duration, 1, copyOpacity, tintGround) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/Color2ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/Color2ColorTrigger.cs
@@ -10,10 +10,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
     /// <summary>Represents a Color 2 Color trigger.</summary>
     public class Color2ColorTrigger : ColorTrigger
     {
-        public override int ObjectID => (int)TriggerType.Color2;
+        public override short ObjectID => (short)(int)TriggerType.Color2;
         
         /// <summary>The target Color ID of the trigger.</summary>
-        public new int TargetColorID => 2;
+        public new short TargetColorID => 2;
 
         /// <summary>Initializes a new instance of the <seealso cref="Color2ColorTrigger"/> class.</summary>
         public Color2ColorTrigger() { }
@@ -22,6 +22,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
         /// <param name="copyOpacity">The Copy Opacity property of the trigger.</param>
         /// <param name="tintGround">The Tint Ground property of the trigger.</param>
         public Color2ColorTrigger(float duration, bool copyOpacity = false, bool tintGround = false)
-            : base(duration, (int)SpecialColorID.BG, copyOpacity, tintGround) { }
+            : base(duration, 2, copyOpacity, tintGround) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/Color3ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/Color3ColorTrigger.cs
@@ -10,10 +10,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
     /// <summary>Represents a Color 3 Color trigger.</summary>
     public class Color3ColorTrigger : ColorTrigger
     {
-        public override int ObjectID => (int)TriggerType.Color3;
+        public override short ObjectID => (short)(int)TriggerType.Color3;
         
         /// <summary>The target Color ID of the trigger.</summary>
-        public new int TargetColorID => 3;
+        public new short TargetColorID => 3;
 
         /// <summary>Initializes a new instance of the <seealso cref="Color3ColorTrigger"/> class.</summary>
         public Color3ColorTrigger() { }
@@ -22,6 +22,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
         /// <param name="copyOpacity">The Copy Opacity property of the trigger.</param>
         /// <param name="tintGround">The Tint Ground property of the trigger.</param>
         public Color3ColorTrigger(float duration, bool copyOpacity = false, bool tintGround = false)
-            : base(duration, (int)SpecialColorID.BG, copyOpacity, tintGround) { }
+            : base(duration, 3, copyOpacity, tintGround) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/Color4ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/Color4ColorTrigger.cs
@@ -10,10 +10,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
     /// <summary>Represents a Color 4 Color trigger.</summary>
     public class Color4ColorTrigger : ColorTrigger
     {
-        public override int ObjectID => (int)TriggerType.Color4;
+        public override short ObjectID => (short)(int)TriggerType.Color4;
         
         /// <summary>The target Color ID of the trigger.</summary>
-        public new int TargetColorID => 4;
+        public new short TargetColorID => 4;
 
         /// <summary>Initializes a new instance of the <seealso cref="Color4ColorTrigger"/> class.</summary>
         public Color4ColorTrigger() { }
@@ -22,6 +22,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
         /// <param name="copyOpacity">The Copy Opacity property of the trigger.</param>
         /// <param name="tintGround">The Tint Ground property of the trigger.</param>
         public Color4ColorTrigger(float duration, bool copyOpacity = false, bool tintGround = false)
-            : base(duration, (int)SpecialColorID.BG, copyOpacity, tintGround) { }
+            : base(duration, 4, copyOpacity, tintGround) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/GRND2ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/GRND2ColorTrigger.cs
@@ -10,10 +10,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
     /// <summary>Represents a GRND2 Color trigger.</summary>
     public class GRND2ColorTrigger : ColorTrigger
     {
-        public override int ObjectID => (int)TriggerType.GRND2;
+        public override short ObjectID => (short)(int)TriggerType.GRND2;
         
         /// <summary>The target Color ID of the trigger.</summary>
-        public new int TargetColorID => (int)SpecialColorID.GRND2;
+        public new short TargetColorID => (short)(int)SpecialColorID.GRND2;
 
         /// <summary>Initializes a new instance of the <seealso cref="GRND2ColorTrigger"/> class.</summary>
         public GRND2ColorTrigger() { }
@@ -21,6 +21,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
         /// <param name="duration">The duration of the trigger.</param>
         /// <param name="tintGround">The Tint Ground property of the trigger.</param>
         public GRND2ColorTrigger(float duration, bool tintGround = false)
-            : base(duration, (int)SpecialColorID.BG, false, tintGround) { }
+            : base(duration, (short)(int)SpecialColorID.GRND2, false, tintGround) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/GRNDColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/GRNDColorTrigger.cs
@@ -10,10 +10,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
     /// <summary>Represents a GRND Color trigger.</summary>
     public class GRNDColorTrigger : ColorTrigger
     {
-        public override int ObjectID => (int)TriggerType.GRND;
+        public override short ObjectID => (short)(int)TriggerType.GRND;
         
         /// <summary>The target Color ID of the trigger.</summary>
-        public new int TargetColorID => (int)SpecialColorID.GRND;
+        public new short TargetColorID => (short)(int)SpecialColorID.GRND;
 
         /// <summary>Initializes a new instance of the <seealso cref="GRNDColorTrigger"/> class.</summary>
         public GRNDColorTrigger() { }
@@ -21,6 +21,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
         /// <param name="duration">The duration of the trigger.</param>
         /// <param name="tintGround">The Tint Ground property of the trigger.</param>
         public GRNDColorTrigger(float duration, bool tintGround = false)
-            : base(duration, (int)SpecialColorID.BG, false, tintGround) { }
+            : base(duration, (short)(int)SpecialColorID.GRND, false, tintGround) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/LineColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/LineColorTrigger.cs
@@ -10,10 +10,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
     /// <summary>Represents a Line Color trigger.</summary>
     public class LineColorTrigger : ColorTrigger
     {
-        public override int ObjectID => (int)TriggerType.Line;
+        public override short ObjectID => (short)(int)TriggerType.Line;
         
         /// <summary>The target Color ID of the trigger.</summary>
-        public new int TargetColorID => (int)SpecialColorID.Line;
+        public new short TargetColorID => (short)(int)SpecialColorID.Line;
 
         /// <summary>Initializes a new instance of the <seealso cref="LineColorTrigger"/> class.</summary>
         public LineColorTrigger() { }
@@ -22,6 +22,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
         /// <param name="copyOpacity">The Copy Opacity property of the trigger.</param>
         /// <param name="tintGround">The Tint Ground property of the trigger.</param>
         public LineColorTrigger(float duration, bool copyOpacity = false, bool tintGround = false)
-            : base(duration, (int)SpecialColorID.BG, copyOpacity, tintGround) { }
+            : base(duration, (short)(int)SpecialColorID.Line, copyOpacity, tintGround) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/ObjColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/ObjColorTrigger.cs
@@ -10,10 +10,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
     /// <summary>Represents an Obj Color trigger.</summary>
     public class ObjColorTrigger : ColorTrigger
     {
-        public override int ObjectID => (int)TriggerType.Obj;
+        public override short ObjectID => (short)(int)TriggerType.Obj;
         
         /// <summary>The target Color ID of the trigger.</summary>
-        public new int TargetColorID => (int)SpecialColorID.Obj;
+        public new short TargetColorID => (short)(int)SpecialColorID.Obj;
 
         /// <summary>Initializes a new instance of the <seealso cref="ObjColorTrigger"/> class.</summary>
         public ObjColorTrigger() { }
@@ -22,6 +22,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
         /// <param name="copyOpacity">The Copy Opacity property of the trigger.</param>
         /// <param name="tintGround">The Tint Ground property of the trigger.</param>
         public ObjColorTrigger(float duration, bool copyOpacity = false, bool tintGround = false)
-            : base(duration, (int)SpecialColorID.BG, copyOpacity, tintGround) { }
+            : base(duration, (short)(int)SpecialColorID.Obj, copyOpacity, tintGround) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/ThreeDLColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTriggers/ThreeDLColorTrigger.cs
@@ -10,10 +10,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
     /// <summary>Represents a 3DL Color trigger.</summary>
     public class ThreeDLColorTrigger : ColorTrigger
     {
-        public override int ObjectID => (int)TriggerType.ThreeDL;
+        public override short ObjectID => (short)(int)TriggerType.ThreeDL;
         
         /// <summary>The target Color ID of the trigger.</summary>
-        public new int TargetColorID => (int)SpecialColorID.ThreeDL;
+        public new short TargetColorID => (short)(int)SpecialColorID.ThreeDL;
 
         /// <summary>Initializes a new instance of the <seealso cref="ThreeDLColorTrigger"/> class.</summary>
         public ThreeDLColorTrigger() { }
@@ -22,6 +22,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.ColorTrigg
         /// <param name="copyOpacity">The Copy Opacity property of the trigger.</param>
         /// <param name="tintGround">The Tint Ground property of the trigger.</param>
         public ThreeDLColorTrigger(float duration, bool copyOpacity = false, bool tintGround = false)
-            : base(duration, (int)SpecialColorID.BG, copyOpacity, tintGround) { }
+            : base(duration, (short)(int)SpecialColorID.ThreeDL, copyOpacity, tintGround) { }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CountTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CountTrigger.cs
@@ -15,12 +15,12 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Count;
         
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The Item ID of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.ItemID)]
-        public int ItemID { get; set; }
+        public short ItemID { get; set; }
         /// <summary>The primary Item ID of the trigger.</summary>
-        public int PrimaryItemID
+        public short PrimaryItemID
         {
             get => ItemID;
             set => ItemID = value;
@@ -30,11 +30,19 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public int TargetCount { get; set; }
         /// <summary>The Activate Group property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.ActivateGroup)]
-        public bool ActivateGroup { get; set; }
+        public bool ActivateGroup
+        {
+            get => TriggerBools[3];
+            set => TriggerBools[3] = value;
+        }
         /// <summary>The Multi Activate property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.MultiActivate)]
-        public bool MultiActivate { get; set; }
-
+        public bool MultiActivate
+        {
+            get => TriggerBools[4];
+            set => TriggerBools[4] = value;
+        }
+        
         /// <summary>Initializes a new instance of the <seealso cref="CountTrigger"/> class.</summary>
         public CountTrigger() { }
         /// <summary>Initializes a new instance of the <seealso cref="CountTrigger"/> class.</summary>
@@ -43,7 +51,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="count">The Target Count property of the trigger.</param>
         /// <param name="activateGroup">The Activate Group property of the trigger.</param>
         /// <param name="multiActivate">The Multi Activate property of the trigger.</param>
-        public CountTrigger(int targetGroupID, int itemID, int targetCount, bool activateGroup = false, bool multiActivate = false)
+        public CountTrigger(short targetGroupID, short itemID, short targetCount, bool activateGroup = false, bool multiActivate = false)
         {
             TargetGroupID = targetGroupID;
             ItemID = itemID;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CountTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CountTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Count trigger.</summary>
     public class CountTrigger : Trigger, IHasTargetGroupID, IHasPrimaryItemID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Count;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Count;
         
         /// <summary>The target Group ID of the trigger.</summary>
         public short TargetGroupID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
@@ -17,7 +17,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The Speed property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.Speed)]
         public float Speed { get; set; }
@@ -36,7 +36,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <summary>Initializes a new instance of the <seealso cref="FollowPlayerYTrigger"/> class.</summary>
         /// <param name="duration">The duration of the trigger.</param>
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
-        public FollowPlayerYTrigger(float duration, int targetGroupID)
+        public FollowPlayerYTrigger(float duration, short targetGroupID)
         {
             Duration = duration;
             TargetGroupID = targetGroupID;
@@ -48,7 +48,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="delay">The Delay property of the trigger.</param>
         /// <param name="maxSpeed">The Max Speed property of the trigger.</param>
         /// <param name="offset">The Offset property of the trigger.</param>
-        public FollowPlayerYTrigger(float duration, int targetGroupID, float speed, float delay, float maxSpeed, int offset)
+        public FollowPlayerYTrigger(float duration, short targetGroupID, float speed, float delay, float maxSpeed, int offset)
             : this(duration, targetGroupID)
         {
             Speed = speed;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Follow Player Y trigger.</summary>
     public class FollowPlayerYTrigger : Trigger, IHasDuration, IHasTargetGroupID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.FollowPlayerY;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.FollowPlayerY;
 
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
@@ -17,9 +17,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The secondary Group ID of the trigger.</summary>
-        public int SecondaryGroupID
+        public short SecondaryGroupID
         {
             get => FollowGroupID;
             set => FollowGroupID = value;
@@ -33,14 +33,14 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <summary>The Follow Group ID property of the trigger.</summary>
         //[ObjectStringMappable(ObjectParameter.FollowGroupID)]
         // Do not also map this property, the interface provides the definition for the one already.
-        public int FollowGroupID { get; set; }
+        public short FollowGroupID { get; set; }
 
         /// <summary>Initializes a new instance of the <seealso cref="FollowTrigger"/> class.</summary>
         public FollowTrigger() { }
         /// <summary>Initializes a new instance of the <seealso cref="FollowTrigger"/> class.</summary>
         /// <param name="duration">The duration of the trigger.</param>
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
-        public FollowTrigger(float duration, int targetGroupID)
+        public FollowTrigger(float duration, short targetGroupID)
         {
             Duration = duration;
             TargetGroupID = targetGroupID;
@@ -50,7 +50,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
         /// <param name="xMod">The X Mod of the trigger.</param>
         /// <param name="yMod">The Y Mod of the trigger.</param>
-        public FollowTrigger(float duration, int targetGroupID, float xMod, float yMod)
+        public FollowTrigger(float duration, short targetGroupID, float xMod, float yMod)
             : this(duration, targetGroupID)
         {
             XMod = xMod;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Follow trigger.</summary>
     public class FollowTrigger : Trigger, IHasDuration, IHasTargetGroupID, IHasSecondaryGroupID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Follow;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Follow;
 
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/InstantCountTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/InstantCountTrigger.cs
@@ -15,12 +15,12 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.InstantCount;
         
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The Item ID of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.ItemID)]
-        public int ItemID { get; set; }
+        public short ItemID { get; set; }
         /// <summary>The primary Item ID of the trigger.</summary>
-        public int PrimaryItemID
+        public short PrimaryItemID
         {
             get => ItemID;
             set => ItemID = value;
@@ -30,7 +30,11 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public int TargetCount { get; set; }
         /// <summary>The Activate Group property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.ActivateGroup)]
-        public bool ActivateGroup { get; set; }
+        public bool ActivateGroup
+        {
+            get => TriggerBools[3];
+            set => TriggerBools[3] = value;
+        }
         /// <summary>The Comparison property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.Comparison)]
         public InstantCountComparison Comparison { get; set; }
@@ -43,7 +47,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="count">The Target Count property of the trigger.</param>
         /// <param name="activateGroup">The Activate Group property of the trigger.</param>
         /// <param name="comparison">The Comparison property of the trigger.</param>
-        public InstantCountTrigger(int targetGroupID, int itemID, int targetCount, bool activateGroup = false, InstantCountComparison comparison = InstantCountComparison.Equals)
+        public InstantCountTrigger(short targetGroupID, short itemID, int targetCount, bool activateGroup = false, InstantCountComparison comparison = InstantCountComparison.Equals)
         {
             TargetGroupID = targetGroupID;
             ItemID = itemID;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/InstantCountTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/InstantCountTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents an Instant Count trigger.</summary>
     public class InstantCountTrigger : Trigger, IHasTargetGroupID, IHasPrimaryItemID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.InstantCount;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.InstantCount;
         
         /// <summary>The target Group ID of the trigger.</summary>
         public short TargetGroupID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasColor.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasColor.cs
@@ -13,12 +13,12 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.Interfaces
     {
         /// <summary>The red part of the color.</summary>
         [ObjectStringMappable(ObjectParameter.Red)]
-        int Red { get; set; }
+        byte Red { get; set; }
         /// <summary>The green part of the color.</summary>
         [ObjectStringMappable(ObjectParameter.Green)]
-        int Green { get; set; }
+        byte Green { get; set; }
         /// <summary>The blue part of the color.</summary>
         [ObjectStringMappable(ObjectParameter.Blue)]
-        int Blue { get; set; }
+        byte Blue { get; set; }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasPrimaryBlockID.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasPrimaryBlockID.cs
@@ -13,6 +13,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.Interfaces
     {
         /// <summary>The primary Block ID of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.BlockAID)]
-        int PrimaryBlockID { get; set; }
+        short PrimaryBlockID { get; set; }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasPrimaryItemID.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasPrimaryItemID.cs
@@ -13,6 +13,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.Interfaces
     {
         /// <summary>The primary Item ID of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.ItemID)]
-        int PrimaryItemID { get; set; }
+        short PrimaryItemID { get; set; }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasSecondaryBlockID.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasSecondaryBlockID.cs
@@ -13,6 +13,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.Interfaces
     {
         /// <summary>The secondary Block ID of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.BlockBID)]
-        int SecondaryBlockID { get; set; }
+        short SecondaryBlockID { get; set; }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasSecondaryGroupID.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasSecondaryGroupID.cs
@@ -13,6 +13,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.Interfaces
     {
         /// <summary>The secondary Group ID of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.SecondaryGroupID)]
-        int SecondaryGroupID { get; }
+        short SecondaryGroupID { get; }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasTargetColorID.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasTargetColorID.cs
@@ -13,6 +13,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.Interfaces
     {
         /// <summary>The target Color ID of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.TargetColorID)]
-        int TargetColorID { get; set; }
+        short TargetColorID { get; set; }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasTargetGroupID.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasTargetGroupID.cs
@@ -13,6 +13,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.Interfaces
     {
         /// <summary>The target Group ID of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.TargetGroupID)]
-        int TargetGroupID { get; set; }
+        short TargetGroupID { get; set; }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasTargetItemID.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Interfaces/IHasTargetItemID.cs
@@ -13,6 +13,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers.Interfaces
     {
         /// <summary>The target Item ID of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.ItemID)]
-        int TargetItemID { get; set; }
+        short TargetItemID { get; set; }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/MoveTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/MoveTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Move trigger.</summary>
     public class MoveTrigger : Trigger, IHasDuration, IHasEasing, IHasTargetGroupID, IHasSecondaryGroupID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Move;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Move;
 
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/MoveTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/MoveTrigger.cs
@@ -17,13 +17,13 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The easing of the trigger.</summary>
         public Easing Easing { get; set; }
         /// <summary>The Move Y of the trigger.</summary>
         public float EasingRate { get; set; }
         /// <summary>The secondary Group ID of the trigger.</summary>
-        public int SecondaryGroupID
+        public short SecondaryGroupID
         {
             get => TargetPosGroupID;
             set => TargetPosGroupID = value;
@@ -36,14 +36,22 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public float MoveY { get; set; }
         /// <summary>The Lock to Player X property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.LockToPlayerX)]
-        public bool LockToPlayerX { get; set; }
+        public bool LockToPlayerX
+        {
+            get => TriggerBools[3];
+            set => TriggerBools[3] = value;
+        }
         /// <summary>The Lock to Player Y property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.LockToPlayerY)]
-        public bool LockToPlayerY { get; set; }
+        public bool LockToPlayerY
+        {
+            get => TriggerBools[4];
+            set => TriggerBools[4] = value;
+        }
         /// <summary>The Target Pos Group ID property of the trigger.</summary>
         //[ObjectStringMappable(ObjectParameter.TargetPosGroupID)]
         // Do not also map this property, the interface provides the definition for the one already.
-        public int TargetPosGroupID { get; set; }
+        public short TargetPosGroupID { get; set; }
         /// <summary>The Target Pos coordinates property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.TargetPosCoordinates)]
         public MoveTargetPosCoordinates TargetPosCoordinates { get; set; }
@@ -55,7 +63,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
         /// <param name="lockToPlayerX">The Lock to Player X property of the trigger.</param>
         /// <param name="lockToPlayerY">The Lock to Player Y property of the trigger.</param>
-        public MoveTrigger(float duration, int targetGroupID, bool lockToPlayerX = false, bool lockToPlayerY = false)
+        public MoveTrigger(float duration, short targetGroupID, bool lockToPlayerX = false, bool lockToPlayerY = false)
         {
             Duration = duration;
             TargetGroupID = targetGroupID;
@@ -69,7 +77,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="moveY">The Move Y of the trigger.</param>
         /// <param name="lockToPlayerX">The Lock to Player X property of the trigger.</param>
         /// <param name="lockToPlayerY">The Lock to Player Y property of the trigger.</param>
-        public MoveTrigger(float duration, int targetGroupID, float moveX, float moveY, bool lockToPlayerX = false, bool lockToPlayerY = false)
+        public MoveTrigger(float duration, short targetGroupID, float moveX, float moveY, bool lockToPlayerX = false, bool lockToPlayerY = false)
             : this(duration, targetGroupID, lockToPlayerX, lockToPlayerY)
         {
             MoveX = moveX;
@@ -84,7 +92,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="easingRate">The easing rate of the trigger.</param>
         /// <param name="lockToPlayerX">The Lock to Player X property of the trigger.</param>
         /// <param name="lockToPlayerY">The Lock to Player Y property of the trigger.</param>
-        public MoveTrigger(float duration, int targetGroupID, Easing easing, float easingRate, float moveX, float moveY, bool lockToPlayerX = false, bool lockToPlayerY = false)
+        public MoveTrigger(float duration, short targetGroupID, Easing easing, float easingRate, float moveX, float moveY, bool lockToPlayerX = false, bool lockToPlayerY = false)
             : this(duration, targetGroupID, moveX, moveY, lockToPlayerX, lockToPlayerY)
         {
             Easing = easing;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/OnDeathTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/OnDeathTrigger.cs
@@ -15,17 +15,21 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.OnDeath;
         
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The Activate Group property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.ActivateGroup)]
-        public bool ActivateGroup { get; set; }
+        public bool ActivateGroup
+        {
+            get => TriggerBools[3];
+            set => TriggerBools[3] = value;
+        }
 
         /// <summary>Initializes a new instance of the <seealso cref="OnDeathTrigger"/> class.</summary>
         public OnDeathTrigger() { }
         /// <summary>Initializes a new instance of the <seealso cref="OnDeathTrigger"/> class.</summary>
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
         /// <param name="activateGroup">The Activate Group property of the trigger.</summary>
-        public OnDeathTrigger(int targetGroupID, bool activateGroup = false)
+        public OnDeathTrigger(short targetGroupID, bool activateGroup = false)
         {
             TargetGroupID = targetGroupID;
             ActivateGroup = activateGroup;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/OnDeathTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/OnDeathTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents an On Death trigger.</summary>
     public class OnDeathTrigger : Trigger, IHasTargetGroupID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.OnDeath;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.OnDeath;
         
         /// <summary>The target Group ID of the trigger.</summary>
         public short TargetGroupID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PickupTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PickupTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Pickup trigger.</summary>
     public class PickupTrigger : Trigger, IHasTargetItemID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Pickup;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Pickup;
         
         /// <summary>The target Item ID of the trigger.</summary>
         public short TargetItemID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PickupTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PickupTrigger.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Pickup;
         
         /// <summary>The target Item ID of the trigger.</summary>
-        public int TargetItemID { get; set; }
+        public short TargetItemID { get; set; }
         /// <summary>The Count property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.Count)]
         public int Count { get; set; }
@@ -25,7 +25,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <summary>Initializes a new instance of the <seealso cref="PickupTrigger"/> class.</summary>
         /// <param name="targetItemID">The target Item ID of the trigger.</param>
         /// <param name="count">The Count property of the trigger.</param>
-        public PickupTrigger(int targetItemID, int count)
+        public PickupTrigger(short targetItemID, int count)
         {
             TargetItemID = targetItemID;
             Count = count;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
@@ -13,7 +13,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Pulse trigger.</summary>
     public class PulseTrigger : Trigger, IHasTargetGroupID, IHasTargetColorID, IHasColor
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Pulse;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Pulse;
 
         /// <summary>The target Group ID of the trigger.</summary>
         public short TargetGroupID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
@@ -16,15 +16,15 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Pulse;
 
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The target Color ID of the trigger.</summary>
-        public int TargetColorID { get; set; }
+        public short TargetColorID { get; set; }
         /// <summary>The red part of the color.</summary>
-        public int Red { get; set; }
+        public byte Red { get; set; }
         /// <summary>The green part of the color.</summary>
-        public int Green { get; set; }
+        public byte Green { get; set; }
         /// <summary>The blue part of the color.</summary>
-        public int Blue { get; set; }
+        public byte Blue { get; set; }
         /// <summary>The Fade In property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.FadeIn)]
         public float FadeIn { get; set; }
@@ -36,7 +36,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public float FadeOut { get; set; }
         /// <summary>The copied Color ID of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.CopiedColorID)]
-        public int CopiedColorID { get; set; }
+        public short CopiedColorID { get; set; }
         /// <summary>The Pulse Mode of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.PulseMode)]
         public PulseMode PulseMode { get; set; }
@@ -45,7 +45,11 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public PulseTargetType PulseTargetType { get; set; }
         /// <summary>The Exclusive property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.Exclusive)]
-        public bool Exclusive { get; set; }
+        public bool Exclusive
+        {
+            get => TriggerBools[3];
+            set => TriggerBools[3] = value;
+        }
         /// <summary>The HSV of the trigger (as a string for the gamesave).</summary>
         [ObjectStringMappable(ObjectParameter.CopiedColorHSVValues)]
         public string HSV => HSVAdjustment.ToString();

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
@@ -66,7 +66,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="targetID">The target ID of the trigger.</param>
         /// <param name="pulseTargetType">The Pulse Target Type of the trigger.</param>
         /// <param name="pulseMode">The Pulse Mode of the trigger.</param>
-        public PulseTrigger(float fadeIn, float hold, float fadeOut, int targetID, PulseTargetType pulseTargetType = PulseTargetType.ColorChannel, PulseMode pulseMode = PulseMode.Color)
+        public PulseTrigger(float fadeIn, float hold, float fadeOut, short targetID, PulseTargetType pulseTargetType = PulseTargetType.ColorChannel, PulseMode pulseMode = PulseMode.Color)
         {
             FadeIn = fadeIn;
             Hold = hold;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RotateTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RotateTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Rotate trigger.</summary>
     public class RotateTrigger : Trigger, IHasDuration, IHasEasing, IHasTargetGroupID, IHasSecondaryGroupID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Rotate;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Rotate;
 
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RotateTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RotateTrigger.cs
@@ -17,13 +17,13 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The easing of the trigger.</summary>
         public Easing Easing { get; set; }
         /// <summary>The Move Y of the trigger.</summary>
         public float EasingRate { get; set; }
         /// <summary>The secondary Group ID of the trigger.</summary>
-        public int SecondaryGroupID
+        public short SecondaryGroupID
         {
             get => CenterGroupID;
             set => CenterGroupID = value;
@@ -36,11 +36,15 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public int Times360 { get; set; }
         /// <summary>The Lock Object Rotation property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.LockObjectRotation)]
-        public bool LockObjectRotation { get; set; }
+        public bool LockObjectRotation
+        {
+            get => TriggerBools[3];
+            set => TriggerBools[3] = value;
+        }
         /// <summary>The Center Group ID property of the trigger.</summary>
         //[ObjectStringMappable(ObjectParameter.CenterGroupID)]
         // Do not also map this property, the interface provides the definition for the one already.
-        public int CenterGroupID { get; set; }
+        public short CenterGroupID { get; set; }
 
         /// <summary>Initializes a new instance of the <seealso cref="RotateTrigger"/> class.</summary>
         public RotateTrigger() { }
@@ -48,7 +52,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="duration">The duration of the trigger.</param>
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
         /// <param name="lockObjectRotation">The Lock Object Rotation property of the trigger.</param>
-        public RotateTrigger(float duration, int targetGroupID, bool lockObjectRotation = false)
+        public RotateTrigger(float duration, short targetGroupID, bool lockObjectRotation = false)
         {
             Duration = duration;
             TargetGroupID = targetGroupID;
@@ -60,7 +64,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="degrees">The Degrees property of the trigger.</param>
         /// <param name="times360">The Times 360 property of the trigger.</param>
         /// <param name="lockObjectRotation">The Lock Object Rotation property of the trigger.</param>
-        public RotateTrigger(float duration, int targetGroupID, int degrees, int times360, bool lockObjectRotation = false)
+        public RotateTrigger(float duration, short targetGroupID, int degrees, int times360, bool lockObjectRotation = false)
             : this(duration, targetGroupID, lockObjectRotation)
         {
             Degrees = degrees;
@@ -74,7 +78,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="easing">The easing of the trigger.</param>
         /// <param name="easingRate">The easing rate of the trigger.</param>
         /// <param name="lockObjectRotation">The Lock Object Rotation property of the trigger.</param>
-        public RotateTrigger(float duration, int targetGroupID, Easing easing, float easingRate, int degrees, int times360, bool lockObjectRotation = false)
+        public RotateTrigger(float duration, short targetGroupID, Easing easing, float easingRate, int degrees, int times360, bool lockObjectRotation = false)
             : this(duration, targetGroupID, degrees, times360, lockObjectRotation)
         {
             Easing = easing;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ShakeTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ShakeTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Shake trigger.</summary>
     public class ShakeTrigger : Trigger, IHasDuration
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Shake;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Shake;
 
         /// <summary>The duration of the trigger's effect.</summary>
         public float Duration { get; set; } = 0.5f;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ShakeTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ShakeTrigger.cs
@@ -29,7 +29,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="duration">The duration of the trigger.</param>
         /// <param name="strength">The Strength property of the trigger.</param>
         /// <param name="interval">The Interval property of the trigger.</param>
-        public ShakeTrigger(int duration, int strength, int interval)
+        public ShakeTrigger(float duration, float strength, float interval)
         {
             Duration = duration;
             Strength = strength;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/SpawnTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/SpawnTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Spawn trigger.</summary>
     public class SpawnTrigger : Trigger, IHasTargetGroupID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Spawn;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Spawn;
         
         /// <summary>The target Group ID of the trigger.</summary>
         public short TargetGroupID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/SpawnTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/SpawnTrigger.cs
@@ -15,13 +15,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Spawn;
         
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The Delay property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.SpawnDelay)]
         public float Delay { get; set; }
         /// <summary>The Editor Disable property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.EditorDisable)]
-        public bool EditorDisable { get; set; }
+        public bool EditorDisable
+        {
+            get => TriggerBools[3];
+            set => TriggerBools[3] = value;
+        }
 
         /// <summary>Initializes a new instance of the <seealso cref="SpawnTrigger"/> class.</summary>
         public SpawnTrigger() { }
@@ -29,7 +33,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
         /// <param name="delay">The Delay property of the trigger.</param>
         /// <param name="editorDisable">The Editor Disable property of the trigger.</param>
-        public SpawnTrigger(int targetGroupID, float delay, bool editorDisable = false)
+        public SpawnTrigger(short targetGroupID, float delay, bool editorDisable = false)
         {
             TargetGroupID = targetGroupID;
             Delay = delay;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StopTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StopTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Stop trigger.</summary>
     public class StopTrigger : Trigger, IHasTargetGroupID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Stop;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Stop;
         
         /// <summary>The target Group ID of the trigger.</summary>
         public short TargetGroupID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StopTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StopTrigger.cs
@@ -15,13 +15,13 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Stop;
         
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
 
         /// <summary>Initializes a new instance of the <seealso cref="StopTrigger"/> class.</summary>
         public StopTrigger() { }
         /// <summary>Initializes a new instance of the <seealso cref="StopTrigger"/> class.</summary>
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
-        public StopTrigger(int targetGroupID)
+        public StopTrigger(short targetGroupID)
         {
             TargetGroupID = targetGroupID;
         }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ToggleTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ToggleTrigger.cs
@@ -15,17 +15,21 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Toggle;
         
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The Activate Group property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.ActivateGroup)]
-        public bool ActivateGroup { get; set; }
+        public bool ActivateGroup
+        {
+            get => TriggerBools[3];
+            set => TriggerBools[3] = value;
+        }
 
         /// <summary>Initializes a new instance of the <seealso cref="ToggleTrigger"/> class.</summary>
         public ToggleTrigger() { }
         /// <summary>Initializes a new instance of the <seealso cref="ToggleTrigger"/> class.</summary>
         /// <param name="targetGroupID">The target Group ID of the trigger.</param>
         /// <param name="activateGroup">The Activate Group property of the trigger.</summary>
-        public ToggleTrigger(int targetGroupID, bool activateGroup = false)
+        public ToggleTrigger(short targetGroupID, bool activateGroup = false)
         {
             TargetGroupID = targetGroupID;
             ActivateGroup = activateGroup;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ToggleTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ToggleTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Toggle trigger.</summary>
     public class ToggleTrigger : Trigger, IHasTargetGroupID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Toggle;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Toggle;
         
         /// <summary>The target Group ID of the trigger.</summary>
         public short TargetGroupID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/TouchTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/TouchTrigger.cs
@@ -12,7 +12,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Touch trigger.</summary>
     public class TouchTrigger : Trigger, IHasTargetGroupID
     {
-        public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Touch;
+        public override short ObjectID => (short)(int)Enumerations.GeometryDash.TriggerType.Touch;
         
         /// <summary>The target Group ID of the trigger.</summary>
         public short TargetGroupID { get; set; }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/TouchTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/TouchTrigger.cs
@@ -15,13 +15,21 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Touch;
         
         /// <summary>The target Group ID of the trigger.</summary>
-        public int TargetGroupID { get; set; }
+        public short TargetGroupID { get; set; }
         /// <summary>The Hold Mode property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.HoldMode)]
-        public bool HoldMode { get; set; }
+        public bool HoldMode
+        {
+            get => TriggerBools[3];
+            set => TriggerBools[3] = value;
+        }
         /// <summary>The Dual Mode property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.DualMode)]
-        public bool DualMode { get; set; }
+        public bool DualMode
+        {
+            get => TriggerBools[4];
+            set => TriggerBools[4] = value;
+        }
         /// <summary>The Toggle Mode property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.ToggleMode)]
         public TouchToggleMode ToggleMode { get; set; }
@@ -33,7 +41,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <param name="holdMode">The Hold Mode property of the trigger.</param>
         /// <param name="dualMode">The Dual Mode property of the trigger.</param>
         /// <param name="toggleMode">The Toggle Mode property of the trigger.</param>
-        public TouchTrigger(int targetGroupID, bool holdMode = false, bool dualMode = false, TouchToggleMode toggleMode = TouchToggleMode.Default)
+        public TouchTrigger(short targetGroupID, bool holdMode = false, bool dualMode = false, TouchToggleMode toggleMode = TouchToggleMode.Default)
         {
             TargetGroupID = targetGroupID;
             HoldMode = holdMode;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
@@ -11,10 +11,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
 {
     public abstract class Trigger : GeneralObject
     {
-        private BitArray8 triggerBools = new BitArray8();
-        
         /// <summary>Contains the <seealso cref="bool"/> values of the trigger. Indices 0, 1, 2 are reserved for Touch Triggered, Spawn Triggered and Multi Trigger respectively.</summary>
-        protected BitArray8 TriggerBools => triggerBools;
+        protected BitArray8 TriggerBools = new BitArray8();
         
         /// <summary>The Object ID of the trigger.</summary>
         // IMPORTANT: If we want to change the object IDs of objects through some function, this has to be reworked

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
@@ -4,13 +4,17 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using GDEdit.Utilities.Attributes;
+using GDEdit.Utilities.Objects.General;
 using GDEdit.Utilities.Enumerations.GeometryDash.GamesaveValues;
 
 namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
 {
     public abstract class Trigger : GeneralObject
     {
-        private bool touchTriggered, spawnTriggered;
+        private BitArray8 triggerBools = new BitArray8();
+        
+        /// <summary>Contains the <seealso cref="bool"/> values of the trigger. Indices 0, 1, 2 are reserved for Touch Triggered, Spawn Triggered and Multi Trigger respectively.</summary>
+        protected BitArray8 TriggerBools => triggerBools;
         
         /// <summary>The Object ID of the trigger.</summary>
         // IMPORTANT: If we want to change the object IDs of objects through some function, this has to be reworked
@@ -21,29 +25,33 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         [ObjectStringMappable(ObjectParameter.TouchTriggered)]
         public bool TouchTriggered
         {
-            get => touchTriggered;
+            get => TriggerBools[0];
             set
             {
-                if (value && spawnTriggered)
-                    spawnTriggered = false;
-                touchTriggered = value;
+                if (value && SpawnTriggered)
+                    SpawnTriggered = false;
+                TriggerBools[0] = value;
             }
         }
         /// <summary>The Spawn Triggered property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.SpawnTriggered)]
         public bool SpawnTriggered
         {
-            get => spawnTriggered;
+            get => TriggerBools[1];
             set
             {
-                if (value && touchTriggered)
-                    touchTriggered = false;
-                spawnTriggered = value;
+                if (value && TouchTriggered)
+                    TouchTriggered = false;
+                TriggerBools[1] = value;
             }
         }
         /// <summary>The Multi Trigger property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.MultiTrigger)]
-        public bool MultiTrigger { get; set; }
+        public bool MultiTrigger
+        {
+            get => TriggerBools[2];
+            set => TriggerBools[2] = value;
+        }
 
         /// <summary>Initializes a new instance of the <seealso cref="Trigger"/> class.</summary>
         public Trigger() { }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
@@ -19,7 +19,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <summary>The Object ID of the trigger.</summary>
         // IMPORTANT: If we want to change the object IDs of objects through some function, this has to be reworked
         [ObjectStringMappable(ObjectParameter.Duration)]
-        public new virtual int ObjectID { get; }
+        public new virtual short ObjectID { get; }
         
         /// <summary>The Touch Triggered property of the trigger.</summary>
         [ObjectStringMappable(ObjectParameter.TouchTriggered)]


### PR DESCRIPTION
**NOTE:** Retrieving the levels from the gamesave is now broken due to changing the types of certain properties from int to byte or short and from double to float. This can be prevented by using some private fields and changing the types of the properties to int and double solely while performing type conversions.

Do not merge yet I guess?