### PR TITLE
Default object values

### DIFF
--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
@@ -24,10 +24,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
     /// <summary>Represents a general object.</summary>
     public class GeneralObject
     {
-        private short[] groupIDs;
+        private short[] groupIDs = new short[0];
         private BitArray8 bools = new BitArray8();
         private short objectID, el1, el2, zLayer, zOrder, color1ID, color2ID;
-        private float rotation, scaling;
+        private float rotation, scaling = 1;
         
         /// <summary>The Object ID of this object.</summary>
         [ObjectStringMappable(ObjectParameter.ID)]

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/SpeedPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/SpeedPortal.cs
@@ -24,7 +24,11 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
         }
 
         /// <summary>Initializes a new instance of the <seealso cref="SpeedPortal"/> class.</summary>
-        public SpeedPortal() : base() { }
+        public SpeedPortal()
+            : base()
+        {
+            Checked = true;
+        }
 
         /// <summary>Adds the cloned instance information and returns the cloned instance.</summary>
         /// <param name="cloned">The cloned instance to add the information to.</param>

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
@@ -18,7 +18,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
 
         /// <summary>The animation speed of the pulsating object as a ratio.</summary>
         [ObjectStringMappable(ObjectParameter.AnimationSpeed)]
-        public float AnimationSpeed { get; set; }
+        public float AnimationSpeed { get; set; } = 1;
         /// <summary>The Randomize Start property of the pulsating object.</summary>
         [ObjectStringMappable(ObjectParameter.RandomizeStart)]
         public bool RandomizeStart

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
@@ -13,8 +13,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Color trigger.</summary>
     public class ColorTrigger : Trigger, IHasTargetColorID, IHasColor, IHasDuration
     {
-        private byte red, green, blue;
-        private short targetColorID;
+        private byte red = 255, green = 255, blue = 255;
+        private short targetColorID = 1;
         private float duration = 0.5f, opacity = 1;
 
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Color;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
@@ -13,7 +13,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     public class FollowPlayerYTrigger : Trigger, IHasDuration, IHasTargetGroupID
     {
         private short targetGroupID;
-        private float duration = 0.5f, speed, delay, maxSpeed;
+        private float duration = 0.5f, speed = 1, delay, maxSpeed;
         
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.FollowPlayerY;
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
@@ -13,7 +13,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     public class FollowTrigger : Trigger, IHasDuration, IHasTargetGroupID, IHasSecondaryGroupID
     {
         private short targetGroupID, followGroupID;
-        private float duration = 0.5f, xMod, yMod;
+        private float duration = 0.5f, xMod = 1, yMod = 1;
 
         public override int ObjectID => (int)Enumerations.GeometryDash.TriggerType.Follow;
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
@@ -13,7 +13,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
     /// <summary>Represents a Pulse trigger.</summary>
     public class PulseTrigger : Trigger, IHasTargetGroupID, IHasTargetColorID, IHasColor
     {
-        private byte red, green, blue;
+        private byte red = 255, green = 255, blue = 255;
         private short targetGroupID, targetColorID;
         private float fadeIn, hold, fadeOut;
 


### PR DESCRIPTION
This adds the default values of all the currently implemented object types to match those of the game.

Reason: During decryption of the level string and initialization of the level objects, only the properties with the selected property IDs are changed; meaning those properties that may not be registered will not have their value initialized, causing potential problems.