### PR TITLE
Support for Linux platforms

### DIFF
--- a/GDEdit/GDEdit/Application/Database.cs
+++ b/GDEdit/GDEdit/Application/Database.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using GDEdit.Utilities.Functions.Extensions;
 using GDEdit.Utilities.Functions.General;
@@ -22,11 +23,11 @@ namespace GDEdit.Application
 
         #region Constants
         /// <summary>The default local data folder path of the game.</summary>
-        public static readonly string GDLocalData = $@"{GetFolderPath(SpecialFolder.LocalApplicationData)}\GeometryDash";
+        public static readonly string GDLocalData = $@"{GetFolderPath(SpecialFolder.LocalApplicationData)}{(/*RuntimeInformation.IsOSPlatform(OSPlatform.Linux)*/OSVersion.Platform == PlatformID.Unix ? "/Steam/steamapps/compatdata/322170/pfx/drive_c/users/steamuser/Local Settings/Application Data/" : @"\")}GeometryDash";
         /// <summary>The default game manager file path of the game.</summary>
-        public static readonly string GDGameManager = $@"{GDLocalData}\CCGameManager.dat";
+        public static readonly string GDGameManager = $@"{GDLocalData}{Path.DirectorySeparatorChar}CCGameManager.dat";
         /// <summary>The default local levels file path of the game.</summary>
-        public static readonly string GDLocalLevels = $@"{GDLocalData}\CCLocalLevels.dat";
+        public static readonly string GDLocalLevels = $@"{GDLocalData}{Path.DirectorySeparatorChar}CCLocalLevels.dat";
         #endregion
 
         #region Information

--- a/GDEdit/GDEdit/Application/Database.cs
+++ b/GDEdit/GDEdit/Application/Database.cs
@@ -23,7 +23,7 @@ namespace GDEdit.Application
 
         #region Constants
         /// <summary>The default local data folder path of the game.</summary>
-		//TODO: Check platform with RuntimeInformation.IsOSPlatform() after mono implements such
+        //TODO: Check platform with RuntimeInformation.IsOSPlatform() after mono implements such
         public static readonly string GDLocalData = $@"{GetFolderPath(SpecialFolder.LocalApplicationData)}{(OSVersion.Platform == PlatformID.Unix ? "/Steam/steamapps/compatdata/322170/pfx/drive_c/users/steamuser/Local Settings/Application Data/" : @"\")}GeometryDash";
         /// <summary>The default game manager file path of the game.</summary>
         public static readonly string GDGameManager = $@"{GDLocalData}{Path.DirectorySeparatorChar}CCGameManager.dat";

--- a/GDEdit/GDEdit/Application/Database.cs
+++ b/GDEdit/GDEdit/Application/Database.cs
@@ -23,7 +23,8 @@ namespace GDEdit.Application
 
         #region Constants
         /// <summary>The default local data folder path of the game.</summary>
-        public static readonly string GDLocalData = $@"{GetFolderPath(SpecialFolder.LocalApplicationData)}{(/*RuntimeInformation.IsOSPlatform(OSPlatform.Linux)*/OSVersion.Platform == PlatformID.Unix ? "/Steam/steamapps/compatdata/322170/pfx/drive_c/users/steamuser/Local Settings/Application Data/" : @"\")}GeometryDash";
+		//TODO: Check platform with RuntimeInformation.IsOSPlatform() after mono implements such
+        public static readonly string GDLocalData = $@"{GetFolderPath(SpecialFolder.LocalApplicationData)}{(OSVersion.Platform == PlatformID.Unix ? "/Steam/steamapps/compatdata/322170/pfx/drive_c/users/steamuser/Local Settings/Application Data/" : @"\")}GeometryDash";
         /// <summary>The default game manager file path of the game.</summary>
         public static readonly string GDGameManager = $@"{GDLocalData}{Path.DirectorySeparatorChar}CCGameManager.dat";
         /// <summary>The default local levels file path of the game.</summary>

--- a/GDEdit/GDEdit/GDEdit.csproj
+++ b/GDEdit/GDEdit/GDEdit.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,16 +40,13 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing.Primitives, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.netcore.app\2.1.0\ref\netcoreapp2.1\System.Drawing.Primitives.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Application\ApplicationDatabase.cs" />


### PR DESCRIPTION
Fixed crash due to incorrect save location and changed assembly reference from System.Drawing.Primitives to System.Drawing to allow GDE to be built under mono