### PR TITLE
XML function refactoring

### DIFF
--- a/GDEdit/GDEdit/GDEdit.csproj
+++ b/GDEdit/GDEdit/GDEdit.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Utilities\Objects\General\Point.cs" />
     <Compile Include="Utilities\Objects\General\BitArray8.cs" />
     <Compile Include="Utilities\Objects\General\TimeSignature.cs" />
+    <Compile Include="Utilities\Objects\General\XMLAnalyzer.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\ColorChannels\ColorChannel.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\CustomLevelObject.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\EditorHelper\OutlineCreationHelperInformation.cs" />

--- a/GDEdit/GDEdit/Utilities/Objects/General/XMLAnalyzer.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/General/XMLAnalyzer.cs
@@ -1,0 +1,62 @@
+﻿using GDEdit.Utilities.Functions.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GDEdit.Utilities.Objects.General
+{
+    /// <summary>Represents an XML analyzer, containing functions to analyze an XML document and get its properties.</summary>
+    public class XMLAnalyzer
+    {
+        // TODO: Add XML document validity checks
+        /// <summary>The XML document.</summary>
+        public string Document { get; }
+
+        /// <summary>Initializes a new instance of the <seealso cref="XMLAnalyzer"/> class.</summary>
+        /// <param name="document">The XML document.</param>
+        public XMLAnalyzer(string document)
+        {
+            Document = document;
+        }
+
+        /// <summary>Analyzes the XML document and retrieves its information, invoking an <seealso cref="XMLEntryHandler"/> object for each entry.</summary>
+        /// <param name="entryHandler">The method to invoke on each entry during the XML document's analysis.</param>
+        public void AnalyzeXMLInformation(XMLEntryHandler entryHandler)
+        {
+            string startKeyString = "<k>";
+            string endKeyString = "</k><";
+            int IDStart;
+            int IDEnd;
+            int valueTypeStart;
+            int valueTypeEnd;
+            int valueStart;
+            int valueEnd;
+            string valueType;
+            string value;
+            for (int i = 0; i < Document.Length;)
+            {
+                IDStart = Document.Find(startKeyString, i, Document.Length) + startKeyString.Length;
+                if (IDStart <= startKeyString.Length)
+                    break;
+                IDEnd = Document.Find(endKeyString, IDStart, Document.Length);
+                valueTypeStart = IDEnd + endKeyString.Length;
+                valueTypeEnd = Document.Find(">", valueTypeStart, Document.Length);
+                valueType = Document.Substring(valueTypeStart, valueTypeEnd - valueTypeStart);
+                valueStart = valueTypeEnd + 1;
+                valueEnd = valueType[valueType.Length - 1] != '/' ? Document.Find($"</{valueType}>", valueStart, Document.Length) : valueStart;
+                value = Document.Substring(valueStart, valueEnd - valueStart);
+                string s = Document.Substring(IDStart, IDEnd - IDStart);
+                entryHandler?.Invoke(s, value, valueType);
+                i = valueEnd;
+            }
+        }
+    }
+
+    /// <summary>Represents a method that handles an XML entry.</summary>
+    /// <param name="key">The key of the XML entry.</param>
+    /// <param name="value">The value of the XML entry.</param>
+    /// <param name="valueType">The type of the value of the XML entry.</param>
+    public delegate void XMLEntryHandler(string key, string value, string valueType);
+}

--- a/GDEdit/GDEdit/Utilities/Objects/General/XMLAnalyzer.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/General/XMLAnalyzer.cs
@@ -25,28 +25,28 @@ namespace GDEdit.Utilities.Objects.General
         /// <param name="entryHandler">The method to invoke on each entry during the XML document's analysis.</param>
         public void AnalyzeXMLInformation(XMLEntryHandler entryHandler)
         {
-            string startKeyString = "<k>";
-            string endKeyString = "</k><";
-            int IDStart;
-            int IDEnd;
-            int valueTypeStart;
-            int valueTypeEnd;
-            int valueStart;
-            int valueEnd;
-            string valueType;
-            string value;
+            const string startKeyString = "<k>";
+            const string endKeyString = "</k><";
+            int IDStart, IDEnd;
+            int valueTypeStart, valueTypeEnd;
+            int valueStart, valueEnd;
+            string valueType, value;
+
             for (int i = 0; i < Document.Length;)
             {
                 IDStart = Document.Find(startKeyString, i, Document.Length) + startKeyString.Length;
                 if (IDStart <= startKeyString.Length)
                     break;
                 IDEnd = Document.Find(endKeyString, IDStart, Document.Length);
+
                 valueTypeStart = IDEnd + endKeyString.Length;
                 valueTypeEnd = Document.Find(">", valueTypeStart, Document.Length);
                 valueType = Document.Substring(valueTypeStart, valueTypeEnd - valueTypeStart);
+
                 valueStart = valueTypeEnd + 1;
                 valueEnd = valueType[valueType.Length - 1] != '/' ? Document.Find($"</{valueType}>", valueStart, Document.Length) : valueStart;
                 value = Document.Substring(valueStart, valueEnd - valueStart);
+
                 string s = Document.Substring(IDStart, IDEnd - IDStart);
                 entryHandler?.Invoke(s, value, valueType);
                 i = valueEnd;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/Level.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/Level.cs
@@ -9,6 +9,7 @@ using GDEdit.Utilities.Enumerations.GeometryDash;
 using GDEdit.Utilities.Functions.Extensions;
 using GDEdit.Utilities.Functions.General;
 using GDEdit.Utilities.Functions.GeometryDash;
+using GDEdit.Utilities.Objects.General;
 using GDEdit.Utilities.Objects.GeometryDash.ColorChannels;
 using GDEdit.Utilities.Objects.GeometryDash.LevelObjects;
 using GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Portals.SpeedPortals;
@@ -189,7 +190,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash
         public string RawLevel
         {
             get => GetRawLevel();
-            set => GetRawInformation(value);
+            set => new XMLAnalyzer(value).AnalyzeXMLInformation(GetRawParameterInformation);
         }
         #endregion
 
@@ -270,35 +271,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash
             for (int i = 0; i < split.Length; i += 2)
                 GetLevelStringParameterInformation(split[i], split[i + 1]);
             LevelObjects = GetObjects(GetObjectString(levelString));
-        }
-        private void GetRawInformation(string raw)
-        {
-            string startKeyString = "<k>";
-            string endKeyString = "</k><";
-            int IDStart;
-            int IDEnd;
-            int valueTypeStart;
-            int valueTypeEnd;
-            int valueStart;
-            int valueEnd;
-            string valueType;
-            string value;
-            for (int i = 0; i < raw.Length;)
-            {
-                IDStart = raw.Find(startKeyString, i, raw.Length) + startKeyString.Length;
-                if (IDStart <= startKeyString.Length)
-                    break;
-                IDEnd = raw.Find(endKeyString, IDStart, raw.Length);
-                valueTypeStart = IDEnd + endKeyString.Length;
-                valueTypeEnd = raw.Find(">", valueTypeStart, raw.Length);
-                valueType = raw.Substring(valueTypeStart, valueTypeEnd - valueTypeStart);
-                valueStart = valueTypeEnd + 1;
-                valueEnd = valueType[valueType.Length - 1] != '/' ? raw.Find($"</{valueType}>", valueStart, raw.Length) : valueStart;
-                value = raw.Substring(valueStart, valueEnd - valueStart);
-                string s = raw.Substring(IDStart, IDEnd - IDStart);
-                GetRawParameterInformation(s, value, valueType);
-                i = valueEnd;
-            }
         }
         private void GetLevelStringParameterInformation(string key, string value)
         {

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/SongMetadata.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/SongMetadata.cs
@@ -1,4 +1,5 @@
 ﻿using GDEdit.Utilities.Functions.Extensions;
+using GDEdit.Utilities.Objects.General;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,14 +35,16 @@ namespace GDEdit.Utilities.Objects.GeometryDash
         /// <summary>Initializes a new instance of the <seealso cref="SongMetadata"/> class.</summary>
         public SongMetadata() { }
 
+        /// <summary>Initializes a new instance of the <seealso cref="SongMetadata"/> class.</summary>
+        /// <param name="data">The data of the <seealso cref="SongMetadata"/>.</param>
+        public SongMetadata(string data)
+        {
+            new XMLAnalyzer(data).AnalyzeXMLInformation(GetSongMetadataParameterInformation);
+        }
+
         /// <summary>Parses the data into a <seealso cref="SongMetadata"/> instance.</summary>
         /// <param name="data">The data to parse into a <seealso cref="SongMetadata"/> instance.</param>
-        public static SongMetadata Parse(string data)
-        {
-            var s = new SongMetadata();
-            s.GetSongMetadataInformation(data);
-            return s;
-        }
+        public static SongMetadata Parse(string data) => new SongMetadata(data);
 
         private void GetSongMetadataParameterInformation(string key, string value, string valueType)
         {
@@ -73,35 +76,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash
                     break;
                 default: // Not something we care about
                     break;
-            }
-        }
-        private void GetSongMetadataInformation(string data)
-        {
-            string startKeyString = "<k>";
-            string endKeyString = "</k><";
-            int IDStart;
-            int IDEnd;
-            int valueTypeStart;
-            int valueTypeEnd;
-            int valueStart;
-            int valueEnd;
-            string valueType;
-            string value;
-            for (int i = 0; i < data.Length;)
-            {
-                IDStart = data.Find(startKeyString, i, data.Length) + startKeyString.Length;
-                if (IDStart <= startKeyString.Length)
-                    break;
-                IDEnd = data.Find(endKeyString, IDStart, data.Length);
-                valueTypeStart = IDEnd + endKeyString.Length;
-                valueTypeEnd = data.Find(">", valueTypeStart, data.Length);
-                valueType = data.Substring(valueTypeStart, valueTypeEnd - valueTypeStart);
-                valueStart = valueTypeEnd + 1;
-                valueEnd = valueType[valueType.Length - 1] != '/' ? data.Find($"</{valueType}>", valueStart, data.Length) : valueStart;
-                value = data.Substring(valueStart, valueEnd - valueStart);
-                string s = data.Substring(IDStart, IDEnd - IDStart);
-                GetSongMetadataParameterInformation(s, value, valueType);
-                i = valueEnd;
             }
         }
 


### PR DESCRIPTION
Closes #54.

The reason why a class was used is the fact that we might need more functionality out of this in the future.