### PR TITLE
Implement object ID hitbox definition dictionary

### DIFF
--- a/GDEdit/GDEdit/GDEdit.csproj
+++ b/GDEdit/GDEdit/GDEdit.csproj
@@ -240,6 +240,7 @@
     <Compile Include="Utilities\Objects\GeometryDash\LevelObjects\Triggers\MoveTrigger.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\LevelObjects\Triggers\Trigger.cs" />
     <Compile Include="Utilities\Objects\General\Shapes\WidthHeightShape.cs" />
+    <Compile Include="Utilities\Objects\GeometryDash\ObjectHitboxes\ObjectHitboxDefinition.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\ObjectSets\ObjectGrid.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\ObjectSets\ObjectSet.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\ObjectSets\ObjectSetPointDictionary.cs" />

--- a/GDEdit/GDEdit/GDEdit.csproj
+++ b/GDEdit/GDEdit/GDEdit.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Utilities\Functions\Extensions\CharExtensions.cs" />
     <Compile Include="Utilities\Functions\Extensions\DictionaryExtensions.cs" />
     <Compile Include="Utilities\Functions\Extensions\GenericArrayExtensions.cs" />
+    <Compile Include="Utilities\Functions\Extensions\GenericICollectionExtensions.cs" />
     <Compile Include="Utilities\Functions\Extensions\GenericListExtensions.cs" />
     <Compile Include="Utilities\Functions\Extensions\IntArrayExtensions.cs" />
     <Compile Include="Utilities\Functions\Extensions\StringExtensions.cs" />
@@ -241,6 +242,7 @@
     <Compile Include="Utilities\Objects\GeometryDash\LevelObjects\Triggers\Trigger.cs" />
     <Compile Include="Utilities\Objects\General\Shapes\WidthHeightShape.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\ObjectHitboxes\ObjectHitboxDefinition.cs" />
+    <Compile Include="Utilities\Objects\GeometryDash\ObjectHitboxes\ObjectHitboxDefinitionDictionary.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\ObjectSets\ObjectGrid.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\ObjectSets\ObjectSet.cs" />
     <Compile Include="Utilities\Objects\GeometryDash\ObjectSets\ObjectSetPointDictionary.cs" />

--- a/GDEdit/GDEdit/Utilities/Functions/Extensions/GenericICollectionExtensions.cs
+++ b/GDEdit/GDEdit/Utilities/Functions/Extensions/GenericICollectionExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GDEdit.Utilities.Functions.Extensions
+{
+    /// <summary>Contains extension functions for the <seealso cref="ICollection{T}"/> interface.</summary>
+    public static class GenericICollectionExtensions
+    {
+        /// <summary>Merges the collection's lists into a single list.</summary>
+        /// <typeparam name="T">The type of the elements in each list of the collection.</typeparam>
+        /// <param name="l">The collection of lists to merge into a list.</param>
+        public static List<T> Merge<T>(this ICollection<List<T>> l)
+        {
+            var result = new List<T>();
+            for (int i = 0; i < l.Count; i++)
+                result.AddRange(l.ElementAt(i));
+            return result;
+        }
+    }
+}

--- a/GDEdit/GDEdit/Utilities/Objects/General/Shapes/Circle.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/General/Shapes/Circle.cs
@@ -10,6 +10,9 @@ namespace GDEdit.Utilities.Objects.General.Shapes
     /// <summary>Represents a circular shape.</summary>
     public class Circle : Shape, IHasRadius
     {
+        /// <summary>Determines whether the Rotation property of the <seealso cref="Shape"/> affects this shape in any way.</summary>
+        protected override bool IsRotationUseful => false;
+
         /// <summary>The radius of the circular shape.</summary>
         public double Radius { get; set; }
 
@@ -27,5 +30,11 @@ namespace GDEdit.Utilities.Objects.General.Shapes
         /// <summary>Determines whether a point is within the shape (assuming the center of the shape is <seealso cref="Point.Zero"/>).</summary>
         /// <param name="point">The point's location.</param>
         public override bool ContainsPoint(Point point) => point.DistanceFrom(Position) <= Radius;
+
+        protected override bool EqualsInheritably(Shape shape)
+        {
+            var other = shape as Circle;
+            return Radius == other.Radius;
+        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/General/Shapes/Line.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/General/Shapes/Line.cs
@@ -10,8 +10,6 @@ namespace GDEdit.Utilities.Objects.General.Shapes
     /// <summary>Represents a line shape.</summary>
     public class Line : Shape
     {
-        /// <summary>The rotation of the line in degrees.</summary>
-        public double Rotation { get; }
         /// <summary>Gets the slope ratio of this line shape.</summary>
         public double SlopeRatio => Math.Tan(Rotation * Math.PI / 180);
 
@@ -29,5 +27,7 @@ namespace GDEdit.Utilities.Objects.General.Shapes
         protected override double CalculateRadiusAtRotation(double rotation) => rotation % 180 == Rotation % 180 ? double.PositiveInfinity : 0;
         /// <summary>Returns the maximum distance between the center of the shape and its edge.</summary>
         public override double GetMaxRadius() => double.PositiveInfinity;
+
+        protected override bool EqualsInheritably(Shape shape) => true;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/General/Shapes/Shape.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/General/Shapes/Shape.cs
@@ -12,6 +12,9 @@ namespace GDEdit.Utilities.Objects.General.Shapes
     {
         private Point position;
 
+        /// <summary>Determines whether the Rotation property of the <seealso cref="Shape"/> affects this shape in any way.</summary>
+        protected virtual bool IsRotationUseful => true;
+
         /// <summary>The rotation of the shape in degrees.</summary>
         public double Rotation { get; set; }
         /// <summary>The position of the shape.</summary>
@@ -74,5 +77,14 @@ namespace GDEdit.Utilities.Objects.General.Shapes
         /// <summary>Determines whether a point is within the shape (assuming the center of the shape is <seealso cref="Point.Zero"/>).</summary>
         /// <param name="point">The point's location.</param>
         public abstract bool ContainsPoint(Point point);
+
+        /// <summary>Determines whether this shape equals another shape. This is a function that defines how to compare shapes of the same type and is only called if both shapes' types are equal.</summary>
+        /// <param name="shape">The shape to determine equality with.</param>
+        protected abstract bool EqualsInheritably(Shape shape);
+
+        private bool Equals(Shape shape) => GetType() == shape.GetType() && position == shape.position && (!IsRotationUseful || Rotation == shape.Rotation) && EqualsInheritably(shape);
+
+        public static bool operator ==(Shape left, Shape right) => left.Equals(right);
+        public static bool operator !=(Shape left, Shape right) => !left.Equals(right);
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/General/Shapes/WidthHeightShape.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/General/Shapes/WidthHeightShape.cs
@@ -67,5 +67,11 @@ namespace GDEdit.Utilities.Objects.General.Shapes
             Point end = new Point(Width / 2, Height / 2) + Position;
             return start <= point && point <= end;
         }
+
+        protected override bool EqualsInheritably(Shape shape)
+        {
+            var other = shape as WidthHeightShape;
+            return Width == other.Width && Height == other.Height;
+        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/Hitbox.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/Hitbox.cs
@@ -61,6 +61,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
         /// <summary>Determines whether the provided hitbox is unnecessary. This evaluates to <see langword="true"/> if the provided hitbox is contained within this hitbox and has the same behavior, otherwise <see langword="false"/>.</summary>
         /// <param name="h">The hitbox to check whether it is unnecessary.</param>
         public bool IsUnnecessaryHitbox(Hitbox h) => h.Behavior == Behavior && Shape.ContainsShape(h.Shape);
+
+        public static bool operator ==(Hitbox left, Hitbox right) => left.Behavior == right.Behavior && left.Position == right.Position && left.Rotation == right.Rotation && left.Shape == right.Shape;
+        public static bool operator !=(Hitbox left, Hitbox right) => left.Behavior != right.Behavior || left.Position != right.Position || left.Rotation != right.Rotation || left.Shape != right.Shape;
     }
 
     /// <summary>Represents a hitbox behavior.</summary>

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/ObjectHitboxDefinition.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/ObjectHitboxDefinition.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
+{
+    /// <summary>Contains information about the object IDs that use this type of hitbox.</summary>
+    public class ObjectHitboxDefinition
+    {
+        /// <summary>The object IDs that this hitbox is valid for.</summary>
+        public List<int> ObjectIDs { get; set; }
+        /// <summary>The hitbox that is valid for the object IDs.</summary>
+        public Hitbox Hitbox { get; set; }
+
+        /// <summary>Initializes a new instance of the <seealso cref="ObjectHitboxDefinition"/> class.</summary>
+        /// <param name="objectID">The object ID that this hitbox is valid for.</param>
+        /// <param name="hitbox">The hitbox of the object IDs.</param>
+        public ObjectHitboxDefinition(int objectID, Hitbox hitbox) : this(new List<int> { objectID }, hitbox) { }
+        /// <summary>Initializes a new instance of the <seealso cref="ObjectHitboxDefinition"/> class.</summary>
+        /// <param name="objectIDs">The object IDs that this hitbox is valid for.</param>
+        /// <param name="hitbox">The hitbox of the object IDs.</param>
+        public ObjectHitboxDefinition(List<int> objectIDs, Hitbox hitbox)
+        {
+            ObjectIDs = objectIDs;
+            Hitbox = hitbox;
+        }
+    }
+}

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/ObjectHitboxDefinition.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/ObjectHitboxDefinition.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GDEdit.Utilities.Functions.Extensions;
 
 namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
 {
@@ -26,5 +27,15 @@ namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
             ObjectIDs = objectIDs;
             Hitbox = hitbox;
         }
+
+        /// <summary>Determines whether this equals another object. It is recommended to use the <seealso cref="Equals(ObjectHitboxDefinition)"/> method if the object is certainly an <seealso cref="ObjectHitboxDefinition"/>.</summary>
+        /// <param name="obj">The other object to compare this with.</param>
+        public override bool Equals(object obj) => (obj is ObjectHitboxDefinition other) && Equals(other);
+        /// <summary>Determines whether this <seealso cref="ObjectHitboxDefinition"/> equals another <seealso cref="ObjectHitboxDefinition"/>.</summary>
+        /// <param name="obj">The other <seealso cref="ObjectHitboxDefinition"/> to compare this with.</param>
+        public bool Equals(ObjectHitboxDefinition other) => other.ObjectIDs.ContainsAll(ObjectIDs) && other.Hitbox == Hitbox;
+
+        public static bool operator ==(ObjectHitboxDefinition left, ObjectHitboxDefinition right) => left.Equals(right);
+        public static bool operator !=(ObjectHitboxDefinition left, ObjectHitboxDefinition right) => !left.Equals(right);
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/ObjectHitboxDefinitionDictionary.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/ObjectHitboxDefinitionDictionary.cs
@@ -117,15 +117,14 @@ namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
                 list.Add(definition);
             else
                 f.ObjectIDs.AddRange(definition.ObjectIDs);
-            if (allIDs != null)
-                allIDs.AddRange(definition.ObjectIDs);
+            allIDs?.AddRange(definition.ObjectIDs);
             Validate();
         }
 
         /// <summary>Clears the dictionary.</summary>
         public void Clear()
         {
-            allIDs.Clear();
+            allIDs?.Clear();
             list.Clear();
         }
 
@@ -178,8 +177,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
             foreach (var d in list)
                 if (d.ObjectIDs.Remove(objectID))
                 {
-                    if (allIDs != null)
-                        allIDs.Remove(objectID);
+                    allIDs?.Remove(objectID);
                     if (d.ObjectIDs.Count == 0)
                         list.Remove(d);
                     return true;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/ObjectHitboxDefinitionDictionary.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/ObjectHitboxDefinitionDictionary.cs
@@ -12,8 +12,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
     /// <summary>Represents a dictionary that contains <seealso cref="ObjectHitboxDefinition"/>s and encapsulates useful manipulation functions. All definitions are unique per value, which means that object IDs and hitboxes have to be unique across the entire dictionary.</summary>
     public class ObjectHitboxDefinitionDictionary : IDictionary<List<int>, Hitbox>, ICollection<ObjectHitboxDefinition>
     {
-        // TOOD: Fix function naming (in)consistency
-
         private List<ObjectHitboxDefinition> list;
         private List<int> allIDs;
 
@@ -76,10 +74,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
         public ObjectHitboxDefinition Find(Hitbox hitbox) => list.Find(d => d.Hitbox == hitbox);
         /// <summary>Returns the <seealso cref="ObjectHitboxDefinition"/> that is common among the specified object IDs.</summary>
         /// <param name="objectIDs">The object IDs to get the common <seealso cref="ObjectHitboxDefinition"/>.</param>
-        public ObjectHitboxDefinition GetCommonObjectIDDefinition(List<int> objectIDs)
+        public ObjectHitboxDefinition GetCommonObjectHitboxDefinition(List<int> objectIDs)
         {
             if (objectIDs.Count == 1)
-                return GetObjectIDDefinition(objectIDs[0]);
+                return GetObjectHitboxDefinition(objectIDs[0]);
             if (objectIDs.Count == 0)
                 throw new ArgumentException("The provided list is empty.");
             foreach (var d in list)
@@ -225,7 +223,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
         {
             try
             {
-                value = GetCommonObjectIDHitbox(key);
+                value = GetCommonHitbox(key);
                 return true;
             }
             catch
@@ -237,7 +235,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
 
         /// <summary>Gets the <seealso cref="ObjectHitboxDefinition"/> that contains a specified object ID.</summary>
         /// <param name="objectID">The object ID that is contained in the returned <seealso cref="ObjectHitboxDefinition"/>.</param>
-        public ObjectHitboxDefinition GetObjectIDDefinition(int objectID)
+        public ObjectHitboxDefinition GetObjectHitboxDefinition(int objectID)
         {
             foreach (var d in list)
                 if (d.ObjectIDs.Contains(objectID))
@@ -246,22 +244,22 @@ namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
         }
         /// <summary>Gets the <seealso cref="Hitbox"/> of a specified object ID.</summary>
         /// <param name="objectID">The object ID whose <seealso cref="Hitbox"/> to get.</param>
-        public Hitbox GetObjectIDHitbox(int objectID) => GetObjectIDDefinition(objectID).Hitbox;
+        public Hitbox GetHitbox(int objectID) => GetObjectHitboxDefinition(objectID).Hitbox;
         /// <summary>Sets the <seealso cref="Hitbox"/> of a specified object ID.</summary>
         /// <param name="objectID">The object ID whose <seealso cref="Hitbox"/> to set.</param>
         /// <param name="hitbox">The <seealso cref="Hitbox"/> to set.</param>
-        public void SetObjectIDHitbox(int objectID, Hitbox hitbox)
+        public void SetHitbox(int objectID, Hitbox hitbox)
         {
             RemoveDefinition(objectID);
             Add(objectID, hitbox);
         }
         /// <summary>Gets the <seealso cref="Hitbox"/> of the specified object IDs. Returns <see langword="null"/> if the object IDs' <seealso cref="Hitbox"/> is not common. Throws respective exceptions on other errors.</summary>
         /// <param name="objectIDs">The object IDs whose common <seealso cref="Hitbox"/> to get.</param>
-        public Hitbox GetCommonObjectIDHitbox(List<int> objectIDs) => GetCommonObjectIDDefinition(objectIDs).Hitbox;
+        public Hitbox GetCommonHitbox(List<int> objectIDs) => GetCommonObjectHitboxDefinition(objectIDs).Hitbox;
         /// <summary>Sets the <seealso cref="Hitbox"/> of a specified object ID. Returns <see langword="null"/> if the object IDs' <seealso cref="Hitbox"/> is not common. Throws respective exceptions on other errors.</summary>
         /// <param name="objectIDs">The object ID whose <seealso cref="Hitbox"/> to set.</param>
         /// <param name="hitbox">The <seealso cref="Hitbox"/> to set.</param>
-        public void SetCommonObjectIDHitbox(List<int> objectIDs, Hitbox hitbox)
+        public void SetCommonHitbox(List<int> objectIDs, Hitbox hitbox)
         {
             RemoveMultipleDefinitions(objectIDs);
             Add(objectIDs, hitbox);
@@ -271,15 +269,15 @@ namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
         /// <param name="objectID">The object ID whose <seealso cref="Hitbox"/> to get or set.</param>
         public Hitbox this[int objectID]
         {
-            get => GetObjectIDHitbox(objectID);
-            set => SetObjectIDHitbox(objectID, value);
+            get => GetHitbox(objectID);
+            set => SetHitbox(objectID, value);
         }
         /// <summary>Gets or sets the <seealso cref="Hitbox"/> of the specified object IDs.</summary>
         /// <param name="objectIDs">The object IDs whose <seealso cref="Hitbox"/> to get or set.</param>
         public Hitbox this[List<int> objectIDs]
         {
-            get => GetCommonObjectIDHitbox(objectIDs);
-            set => SetCommonObjectIDHitbox(objectIDs, value);
+            get => GetCommonHitbox(objectIDs);
+            set => SetCommonHitbox(objectIDs, value);
         }
 
         private void RemoveFromAllIDs(List<int> objectIDs)

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/ObjectHitboxDefinitionDictionary.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/ObjectHitboxes/ObjectHitboxDefinitionDictionary.cs
@@ -1,0 +1,330 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GDEdit.Utilities.Functions.Extensions;
+using System.Collections;
+
+namespace GDEdit.Utilities.Objects.GeometryDash.ObjectHitboxes
+{
+    /// <summary>Represents a dictionary that contains <seealso cref="ObjectHitboxDefinition"/>s and encapsulates useful manipulation functions. All definitions are unique per value, which means that object IDs and hitboxes have to be unique across the entire dictionary.</summary>
+    public class ObjectHitboxDefinitionDictionary : IDictionary<List<int>, Hitbox>, ICollection<ObjectHitboxDefinition>
+    {
+        // TOOD: Fix function naming (in)consistency
+
+        private List<ObjectHitboxDefinition> list;
+        private List<int> allIDs;
+
+        /// <summary>Determines whether the dictionary is read only (it's not).</summary>
+        public bool IsReadOnly => false;
+        /// <summary>Retrieves the count of definition entries.</summary>
+        public int Count => list.Count;
+
+        /// <summary>Gets all the object IDs that are defined in this dictionary.</summary>
+        public ICollection<int> AllObjectIDs
+        {
+            get
+            {
+                if (allIDs == null)
+                {
+                    allIDs = new List<int>();
+                    foreach (var d in list)
+                        allIDs.AddRange(d.ObjectIDs);
+                }
+                return allIDs;
+            }
+        }
+
+        /// <summary>Gets the keys of the dictionary.</summary>
+        public ICollection<List<int>> Keys
+        {
+            get
+            {
+                var result = new List<List<int>>();
+                foreach (var d in list)
+                    result.Add(d.ObjectIDs);
+                return result;
+            }
+        }
+        /// <summary>Gets the values of the dictionary.</summary>
+        public ICollection<Hitbox> Values
+        {
+            get
+            {
+                var result = new List<Hitbox>();
+                foreach (var d in list)
+                    result.Add(d.Hitbox);
+                return result;
+            }
+        }
+
+        /// <summary>Initializes a new instance of the <seealso cref="ObjectHitboxDefinitionDictionary"/> class.</summary>
+        /// <param name="l">The list of <seealso cref="ObjectHitboxDefinition"/> to initialize the <seealso cref="ObjectHitboxDefinitionDictionary"/> out of.</param>
+        public ObjectHitboxDefinitionDictionary(List<ObjectHitboxDefinition> l)
+        {
+            list = l;
+            Validate();
+        }
+
+        /// <summary>Returns a <seealso cref="ObjectHitboxDefinition"/> that matches a given list of object IDs or <see langword="null"/> if not found.</summary>
+        /// <param name="objectIDs">The list of object IDs that the requested <seealso cref="ObjectHitboxDefinition"/> contains.</param>
+        public ObjectHitboxDefinition Find(List<int> objectIDs) => list.Find(d => d.ObjectIDs.ContainsAll(objectIDs));
+        /// <summary>Returns a <seealso cref="ObjectHitboxDefinition"/> that matches a given list of object IDs or <see langword="null"/> if not found.</summary>
+        /// <param name="hitbox">The hitbox that the requested <seealso cref="ObjectHitboxDefinition"/> contains.</param>
+        public ObjectHitboxDefinition Find(Hitbox hitbox) => list.Find(d => d.Hitbox == hitbox);
+        /// <summary>Returns the <seealso cref="ObjectHitboxDefinition"/> that is common among the specified object IDs.</summary>
+        /// <param name="objectIDs">The object IDs to get the common <seealso cref="ObjectHitboxDefinition"/>.</param>
+        public ObjectHitboxDefinition GetCommonObjectIDDefinition(List<int> objectIDs)
+        {
+            if (objectIDs.Count == 1)
+                return GetObjectIDDefinition(objectIDs[0]);
+            if (objectIDs.Count == 0)
+                throw new ArgumentException("The provided list is empty.");
+            foreach (var d in list)
+            {
+                bool found = false;
+                bool contains;
+                for (int i = 0; i < objectIDs.Count; i++)
+                    if (contains = d.ObjectIDs.Contains(objectIDs[i]))
+                        found = true;
+                    else if (found && !contains)
+                        return null;
+                    else
+                        break;
+                if (found)
+                    return d;
+            }
+            throw new KeyNotFoundException("Some of the selected object IDs could not be addressed in the current dictionary.");
+        }
+
+        /// <summary>Adds a new <seealso cref="ObjectHitboxDefinition"/> to the dictionary.</summary>
+        /// <param name="objectID">The object ID to use.</param>
+        /// <param name="hitbox">The <seealso cref="Hitbox"/> that will be added.</param>
+        public void Add(int objectID, Hitbox hitbox) => Add(new ObjectHitboxDefinition(objectID, hitbox));
+        /// <summary>Adds a new <seealso cref="ObjectHitboxDefinition"/> to the dictionary.</summary>
+        /// <param name="objectIDs">The object IDs to use.</param>
+        /// <param name="hitbox">The <seealso cref="Hitbox"/> that will be added.</param>
+        public void Add(List<int> objectIDs, Hitbox hitbox) => Add(new ObjectHitboxDefinition(objectIDs, hitbox));
+        /// <summary>Adds a new <seealso cref="ObjectHitboxDefinition"/> to the dictionary.</summary>
+        /// <param name="entry">The key/value pair to add to the dictionary.</param>
+        public void Add(KeyValuePair<List<int>, Hitbox> entry) => Add(entry.Key, entry.Value);
+        /// <summary>Adds a new <seealso cref="ObjectHitboxDefinition"/> to the dictionary.</summary>
+        /// <param name="definition">The <seealso cref="ObjectHitboxDefinition"/> to add to the dictionary.</param>
+        public void Add(ObjectHitboxDefinition definition)
+        {
+            var f = Find(definition.Hitbox);
+            if (f == null)
+                list.Add(definition);
+            else
+                f.ObjectIDs.AddRange(definition.ObjectIDs);
+            if (allIDs != null)
+                allIDs.AddRange(definition.ObjectIDs);
+            Validate();
+        }
+
+        /// <summary>Clears the dictionary.</summary>
+        public void Clear()
+        {
+            allIDs.Clear();
+            list.Clear();
+        }
+
+        /// <summary>Determines whether the dictionary contains an entry with the specified object IDs mapped to the specified hitbox.</summary>
+        /// <param name="objectIDs">The object IDs to check whether they are mapped to the specified hitbox.</param>
+        /// <param name="hitbox">The hitbox to check whether it's mapped to the specified object IDs.</param>
+        public bool Contains(List<int> objectIDs, Hitbox hitbox) => list.Any(m => m.ObjectIDs.ContainsAll(objectIDs) && m.Hitbox == hitbox);
+        /// <summary>Determines whether the dictionary contains a definition with the specified object IDs and the respective hitbox.</summary>
+        /// <param name="entry">The key/value pair containing information for a respective <seealso cref="ObjectHitboxDefinition"/> object.</param>
+        public bool Contains(KeyValuePair<List<int>, Hitbox> entry) => Contains(entry.Key, entry.Value);
+        /// <summary>Determines whether the dictionary contains a definition with the specified object IDs and the respective hitbox.</summary>
+        /// <param name="definition">The <seealso cref="ObjectHitboxDefinition"/> to check if it is contained.</param>
+        public bool Contains(ObjectHitboxDefinition definition) => list.Contains(definition);
+        /// <summary>Determines whether the dictionary contains a key with the specified object IDs.</summary>
+        /// <param name="objectIDs">The object IDs of the key.</param>
+        public bool ContainsKey(List<int> objectIDs) => list.Any(d => d.ObjectIDs.ContainsAll(objectIDs));
+
+        /// <summary>Removes the dictionary entry with the specified object IDs.</summary>
+        /// <param name="objectIDs">The object IDs of the key of the entry to remove.</param>
+        public bool Remove(List<int> objectIDs) => Remove(Find(objectIDs));
+        /// <summary>Finds the dictionary entry that has a specified hitbox for value and removes the specified object IDs from its definition.</summary>
+        /// <param name="objectIDs">The object IDs to remove from the definition.</param>
+        /// <param name="hitbox">The hitbox of the entry whose object IDs to remove.</param>
+        public bool Remove(List<int> objectIDs, Hitbox hitbox)
+        {
+            var d = Find(objectIDs);
+            if (d.Hitbox == hitbox)
+            {
+                RemoveFromAllIDs(objectIDs);
+                return list.Remove(d);
+            }
+            return false;
+        }
+        /// <summary>Finds the dictionary entry that has a specified hitbox for value and removes the specified object IDs from its definition based on a key/value pair.</summary>
+        /// <param name="entry">The key/value pair that contains the information to determine the entry.</param>
+        public bool Remove(KeyValuePair<List<int>, Hitbox> entry) => Remove(entry.Key, entry.Value);
+        /// <summary>Removes the specified <seealso cref="ObjectHitboxDefinition"/> from the dictionary.</summary>
+        /// <param name="definition">The <seealso cref="ObjectHitboxDefinition"/> to remove from the dictionary.</param>
+        public bool Remove(ObjectHitboxDefinition definition)
+        {
+            bool result = list.Remove(definition);
+            if (result)
+                RemoveFromAllIDs(definition.ObjectIDs);
+            return result;
+        }
+        /// <summary>Removes the definition of a specified object ID. If the associated entry contains no other elements, it is also removed from the dictionary altogether.</summary>
+        /// <param name="objectID">The object ID whose definition to remove.</param>
+        public bool RemoveDefinition(int objectID)
+        {
+            foreach (var d in list)
+                if (d.ObjectIDs.Remove(objectID))
+                {
+                    if (allIDs != null)
+                        allIDs.Remove(objectID);
+                    if (d.ObjectIDs.Count == 0)
+                        list.Remove(d);
+                    return true;
+                }
+            return false;
+        }
+        /// <summary>Removes the definitions of the specified object IDs. If the associated entries contain no other elements, they are also removed from the dictionary altogether.</summary>
+        /// <param name="objectIDs">The object IDs whose definitions to remove.</param>
+        public void RemoveMultipleDefinitions(List<int> objectIDs)
+        {
+            var c = objectIDs.Clone();
+            for (int i = list.Count - 1; i >= 0; i--)
+            {
+                for (int j = c.Count - 1; j >= 0; j--)
+                    if (list[i].ObjectIDs.Remove(c[j]))
+                        c.RemoveAt(j);
+                if (list[i].ObjectIDs.Count == 0)
+                    list.RemoveAt(i);
+            }
+            RemoveFromAllIDs(objectIDs);
+        }
+
+        // Absolutely disgusting code that should not be necessary
+        IEnumerator IEnumerable.GetEnumerator() => new Enumerator(this);
+        IEnumerator<ObjectHitboxDefinition> IEnumerable<ObjectHitboxDefinition>.GetEnumerator() => new Enumerator(this);
+        IEnumerator<KeyValuePair<List<int>, Hitbox>> IEnumerable<KeyValuePair<List<int>, Hitbox>>.GetEnumerator() => new KVPEnumerator(this);
+
+        /// <summary>A useless function that nobody will and should ever touch.</summary>
+        /// <param name="target">Seriously I'm wasting more time writing this documentation than actually implementing the function.</param>
+        /// <param name="startIndex">Why would I give up? It takes less brain power to generate this "documentation".</param>
+        public void CopyTo(KeyValuePair<List<int>, Hitbox>[] target, int startIndex) { }
+        /// <summary>A useless function that nobody will and should ever touch. Version 2.0b</summary>
+        /// <param name="target">Seriously I'm wasting more time writing this documentation than actually implementing the function.</param>
+        /// <param name="startIndex">Why would I give up? It takes less brain power to generate this "documentation".</param>
+        public void CopyTo(ObjectHitboxDefinition[] target, int startIndex) { }
+
+        /// <summary>Attempts to get the value of a specified key. Returns <see langword="true"/> if the operation succeeded, otherwise <see langword="false"/>.</summary>
+        /// <param name="key">The key to try to get the value of in this <seealso cref="ObjectHitboxDefinitionDictionary"/>.</param>
+        /// <param name="value">The value of the key. If the operation failed, <see langword="null"/> is returned.</param>
+        public bool TryGetValue(List<int> key, out Hitbox value)
+        {
+            try
+            {
+                value = GetCommonObjectIDHitbox(key);
+                return true;
+            }
+            catch
+            {
+                value = null;
+                return false;
+            }
+        }
+
+        /// <summary>Gets the <seealso cref="ObjectHitboxDefinition"/> that contains a specified object ID.</summary>
+        /// <param name="objectID">The object ID that is contained in the returned <seealso cref="ObjectHitboxDefinition"/>.</param>
+        public ObjectHitboxDefinition GetObjectIDDefinition(int objectID)
+        {
+            foreach (var d in list)
+                if (d.ObjectIDs.Contains(objectID))
+                    return d;
+            throw new KeyNotFoundException("The selected object ID could not be addressed in the current dictionary.");
+        }
+        /// <summary>Gets the <seealso cref="Hitbox"/> of a specified object ID.</summary>
+        /// <param name="objectID">The object ID whose <seealso cref="Hitbox"/> to get.</param>
+        public Hitbox GetObjectIDHitbox(int objectID) => GetObjectIDDefinition(objectID).Hitbox;
+        /// <summary>Sets the <seealso cref="Hitbox"/> of a specified object ID.</summary>
+        /// <param name="objectID">The object ID whose <seealso cref="Hitbox"/> to set.</param>
+        /// <param name="hitbox">The <seealso cref="Hitbox"/> to set.</param>
+        public void SetObjectIDHitbox(int objectID, Hitbox hitbox)
+        {
+            RemoveDefinition(objectID);
+            Add(objectID, hitbox);
+        }
+        /// <summary>Gets the <seealso cref="Hitbox"/> of the specified object IDs. Returns <see langword="null"/> if the object IDs' <seealso cref="Hitbox"/> is not common. Throws respective exceptions on other errors.</summary>
+        /// <param name="objectIDs">The object IDs whose common <seealso cref="Hitbox"/> to get.</param>
+        public Hitbox GetCommonObjectIDHitbox(List<int> objectIDs) => GetCommonObjectIDDefinition(objectIDs).Hitbox;
+        /// <summary>Sets the <seealso cref="Hitbox"/> of a specified object ID. Returns <see langword="null"/> if the object IDs' <seealso cref="Hitbox"/> is not common. Throws respective exceptions on other errors.</summary>
+        /// <param name="objectIDs">The object ID whose <seealso cref="Hitbox"/> to set.</param>
+        /// <param name="hitbox">The <seealso cref="Hitbox"/> to set.</param>
+        public void SetCommonObjectIDHitbox(List<int> objectIDs, Hitbox hitbox)
+        {
+            RemoveMultipleDefinitions(objectIDs);
+            Add(objectIDs, hitbox);
+        }
+
+        /// <summary>Gets or sets the <seealso cref="Hitbox"/> of a specified object ID.</summary>
+        /// <param name="objectID">The object ID whose <seealso cref="Hitbox"/> to get or set.</param>
+        public Hitbox this[int objectID]
+        {
+            get => GetObjectIDHitbox(objectID);
+            set => SetObjectIDHitbox(objectID, value);
+        }
+        /// <summary>Gets or sets the <seealso cref="Hitbox"/> of the specified object IDs.</summary>
+        /// <param name="objectIDs">The object IDs whose <seealso cref="Hitbox"/> to get or set.</param>
+        public Hitbox this[List<int> objectIDs]
+        {
+            get => GetCommonObjectIDHitbox(objectIDs);
+            set => SetCommonObjectIDHitbox(objectIDs, value);
+        }
+
+        private void RemoveFromAllIDs(List<int> objectIDs)
+        {
+            if (allIDs != null)
+                foreach (var o in objectIDs)
+                    allIDs.Remove(o);
+        }
+        private void Validate()
+        {
+            if (AllObjectIDs.Count != AllObjectIDs.Distinct().Count())
+                throw new InvalidOperationException("The dictionary cannot contain duplicate object ID entries.");
+        }
+
+        #region Please collapse this
+        // Even more absolutely disgusting code that should not be necessary
+        private class Enumerator : IEnumerator<ObjectHitboxDefinition>
+        {
+            private int index;
+            private ObjectHitboxDefinitionDictionary dictionary;
+
+            object IEnumerator.Current => dictionary.list[index];
+            public ObjectHitboxDefinition Current => dictionary.list[index];
+
+            public Enumerator(ObjectHitboxDefinitionDictionary d) => dictionary = d;
+
+            public bool MoveNext() => ++index < dictionary.Count;
+            public void Reset() => index = 0;
+            public void Dispose() { }
+        }
+        private class KVPEnumerator : IEnumerator<KeyValuePair<List<int>, Hitbox>>
+        {
+            private int index;
+            private ObjectHitboxDefinitionDictionary dictionary;
+            private ObjectHitboxDefinition current => dictionary.list[index];
+
+            object IEnumerator.Current => dictionary.list[index];
+            public KeyValuePair<List<int>, Hitbox> Current => new KeyValuePair<List<int>, Hitbox>(current.ObjectIDs, current.Hitbox);
+
+            public KVPEnumerator(ObjectHitboxDefinitionDictionary d) => dictionary = d;
+
+            public bool MoveNext() => ++index < dictionary.Count;
+            public void Reset() => index = 0;
+            public void Dispose() { }
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
This implements a system that allows storing information regarding the hitboxes of respective object IDs. Its practical application is foreseen as the following:
- Store the object ID hitbox definitions in a file with a format like the following:
```
<objectIDs>:<hitboxType>,<shapeName>,<rotation>,<otherParameters>
1;2;3;4:Platform,Square,0,30
5;Hazard,Rectangle,0,30,10
6;Trigger,Circle,0
69;Hazard,VerticalLine,0
```
- Read them on startup and cache them as a dependency (there is no parsing function implemented in this PR)

The usage area is planned to be hitbox calculation of a speed portal and calculation of the level's length and playtesting.