### PR TITLE
Implement object equality and improve object cloning

### DIFF
--- a/GDEdit/GDEdit/Utilities/Functions/Extensions/IntArrayExtensions.cs
+++ b/GDEdit/GDEdit/Utilities/Functions/Extensions/IntArrayExtensions.cs
@@ -198,5 +198,50 @@ namespace GDEdit.Utilities.Functions.Extensions
                     indices.Add(i);
             return indices.ToArray();
         }
+
+        /// <summary>Determines whether all the elements of the <seealso cref="short"/>[] are equal to all the respective elements <seealso cref="short"/>[] in any order.</summary>
+        /// <param name="a">The first array to check for unordered equality.</param>
+        /// <param name="other">The second array to check for unordered equality.</param>
+        public static bool EqualsUnordered(this short[] a, short[] other)
+        {
+            if (a.Length != other.Length)
+                return false;
+            var cloned = other.CopyArray();
+            bool found = false;
+            for (int i = 0; i < a.Length; i++)
+            {
+                for (int j = i; j < a.Length; j++)
+                    if (found = a[i] == cloned[j])
+                    {
+                        cloned.Swap(i, j);
+                        break;
+                    }
+                if (!found)
+                    return false;
+            }
+            return true;
+        }
+        /// <summary>Determines whether all the elements of the <seealso cref="int"/>[] are equal to all the respective elements <seealso cref="int"/>[] in any order.</summary>
+        /// <param name="a">The first array to check for unordered equality.</param>
+        /// <param name="other">The second array to check for unordered equality.</param>
+        public static bool EqualsUnordered(this int[] a, int[] other)
+        {
+            if (a.Length != other.Length)
+                return false;
+            var cloned = other.CopyArray();
+            bool found = false;
+            for (int i = 0; i < a.Length; i++)
+            {
+                for (int j = i; j < a.Length; j++)
+                    if (found = a[i] == cloned[j])
+                    {
+                        cloned.Swap(i, j);
+                        break;
+                    }
+                if (!found)
+                    return false;
+            }
+            return true;
+        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/General/BitArray16.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/General/BitArray16.cs
@@ -37,7 +37,10 @@
             get => GetBoolBit(index);
             set => SetBoolBit(index, value);
         }
-        
+
+        public static bool operator ==(BitArray16 left, BitArray16 right) => left.bits == right.bits;
+        public static bool operator !=(BitArray16 left, BitArray16 right) => left.bits != right.bits;
+
         // Methods are private to avoid handling exceptions
         private static bool GetBool(ushort b) => b == 1;
         private static byte GetByte(bool b) => b ? (byte)1 : (byte)0;

--- a/GDEdit/GDEdit/Utilities/Objects/General/BitArray8.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/General/BitArray8.cs
@@ -37,7 +37,10 @@
             get => GetBoolBit(index);
             set => SetBoolBit(index, value);
         }
-        
+
+        public static bool operator ==(BitArray8 left, BitArray8 right) => left.bits == right.bits;
+        public static bool operator !=(BitArray8 left, BitArray8 right) => left.bits != right.bits;
+
         // Methods are private to avoid handling exceptions
         private static bool GetBool(byte b) => b == 1;
         private static byte GetByte(bool b) => b ? (byte)1 : (byte)0;

--- a/GDEdit/GDEdit/Utilities/Objects/General/Color.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/General/Color.cs
@@ -52,6 +52,9 @@ namespace GDEdit.Utilities.Objects.General
             a = alpha;
         }
 
+        public static bool operator ==(Color left, Color right) => left.r == right.r && left.g == right.g && left.b == right.b && left.a == right.a;
+        public static bool operator !=(Color left, Color right) => left.r != right.r && left.g != right.g && left.b != right.b && left.a != right.a;
+
         private struct ColorValue
         {
             private float v;
@@ -75,6 +78,9 @@ namespace GDEdit.Utilities.Objects.General
 
             public static implicit operator float(ColorValue v) => v.v;
             public static implicit operator ColorValue(float f) => new ColorValue(f);
+
+            public static bool operator ==(ColorValue left, ColorValue right) => left.v == right.v;
+            public static bool operator !=(ColorValue left, ColorValue right) => left.v != right.v;
         }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/General/SymmetricalRange.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/General/SymmetricalRange.cs
@@ -24,4 +24,16 @@ namespace GDEdit.Utilities.Objects.General
             MaximumDistance = maximumDistance;
         }
     }
+
+    // This is so sad, can we get some language improvements please?
+    public static class SymmetricalRangeMethods
+    {
+        public static bool AreEqual(SymmetricalRange<byte> left, SymmetricalRange<byte> right) => left.MiddleValue == right.MiddleValue && left.MaximumDistance == right.MaximumDistance;
+        public static bool AreEqual(SymmetricalRange<short> left, SymmetricalRange<short> right) => left.MiddleValue == right.MiddleValue && left.MaximumDistance == right.MaximumDistance;
+        public static bool AreEqual(SymmetricalRange<int> left, SymmetricalRange<int> right) => left.MiddleValue == right.MiddleValue && left.MaximumDistance == right.MaximumDistance;
+        public static bool AreEqual(SymmetricalRange<long> left, SymmetricalRange<long> right) => left.MiddleValue == right.MiddleValue && left.MaximumDistance == right.MaximumDistance;
+        public static bool AreEqual(SymmetricalRange<float> left, SymmetricalRange<float> right) => left.MiddleValue == right.MiddleValue && left.MaximumDistance == right.MaximumDistance;
+        public static bool AreEqual(SymmetricalRange<double> left, SymmetricalRange<double> right) => left.MiddleValue == right.MiddleValue && left.MaximumDistance == right.MaximumDistance;
+        public static bool AreEqual(SymmetricalRange<Color> left, SymmetricalRange<Color> right) => left.MiddleValue == right.MiddleValue && left.MaximumDistance == right.MaximumDistance;
+    }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/General/HSVDifference.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/General/HSVDifference.cs
@@ -71,17 +71,19 @@ namespace GDEdit.Utilities.Objects.GeometryDash.General
 
         public static bool operator ==(HSVAdjustment left, HSVAdjustment right)
         {
-            foreach (var p in typeof(HSVAdjustment).GetProperties())
-                if (p.GetValue(left) != p.GetValue(right))
-                    return false;
-            return true;
+            return left.h == right.h
+                && left.s == right.s
+                && left.v == right.v
+                && left.saturationMode == right.saturationMode
+                && left.brightnessMode == right.brightnessMode;
         }
         public static bool operator !=(HSVAdjustment left, HSVAdjustment right)
         {
-            foreach (var p in typeof(HSVAdjustment).GetProperties())
-                if (p.GetValue(left) == p.GetValue(right))
-                    return false;
-            return true;
+            return left.h != right.h
+                || left.s != right.s
+                || left.v != right.v
+                || left.saturationMode != right.saturationMode
+                || left.brightnessMode != right.brightnessMode;
         }
 
         /// <summary>Resets this <seealso cref="HSVAdjustment"/>.</summary>
@@ -116,7 +118,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.General
             public T Value
             {
                 get => v;
-                set => v = value = Clamp(value);
+                set => v = Clamp(value);
             }
 
             /// <summary>Initializes a new instance of the <seealso cref="BoundedValue{T}"/> class.</summary>
@@ -133,6 +135,13 @@ namespace GDEdit.Utilities.Objects.GeometryDash.General
             /// <summary>Clamps the value between the two boundaries and returns the clamped result.</summary>
             /// <param name="value">The value to clamp.</param>
             protected abstract T Clamp(T value);
+
+            /// <summary>Detetmines whether this instance's value equals a specific value.</summary>
+            /// <param name="value">The value to compare this instance's value with.</param>
+            protected abstract bool EqualsValue(T value);
+
+            public static bool operator ==(BoundedValue<T> left, BoundedValue<T> right) => left.EqualsValue(right.Value);
+            public static bool operator !=(BoundedValue<T> left, BoundedValue<T> right) => !left.EqualsValue(right.Value);
         }
         private abstract class BoundedFloat : BoundedValue<float>
         {
@@ -146,6 +155,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.General
                     value = Max;
                 return value;
             }
+
+            protected override bool EqualsValue(float value) => Value == value;
         }
         private abstract class BoundedShort : BoundedValue<short>
         {
@@ -159,6 +170,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.General
                     value = Max;
                 return value;
             }
+
+            protected override bool EqualsValue(short value) => Value == value;
         }
         private class H : BoundedShort
         {

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/ConstantIDObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/ConstantIDObject.cs
@@ -15,7 +15,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
         /// <summary>The Object ID of the object.</summary>
         // IMPORTANT: If we want to change the object IDs of objects through some function, this has to be reworked
         [ObjectStringMappable(ObjectParameter.ID)]
-        public new virtual int ObjectID { get; }
+        public new abstract int ObjectID { get; }
 
         /// <summary>Initializes a new instance of the <seealso cref="ConstantIDObject"/> class.</summary>
         public ConstantIDObject()

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
@@ -265,7 +265,40 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
         /// <param name="endingX">The ending X position of the rectangle.</param>
         /// <param name="endingY">The ending Y position of the rectangle.</param>
         public bool IsWithinRange(double startingX, double startingY, double endingX, double endingY) => startingX <= X && endingX >= X && startingY <= Y && endingY >= Y;
-        
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function before returning the result. That means an <see langword="override"/> should look like <see langword="return"/> ... &amp;&amp; <see langword="base"/>.EqualsInherited(<paramref name="other"/>);.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected virtual bool EqualsInherited(GeneralObject other)
+        {
+            // Seriously I do not like how this looks, but at least there is some symmetry, which is the most I could think of
+            return bools == other.bools
+                && color1ID == other.color1ID
+                && color2ID == other.color2ID
+                && el1 == other.el1
+                && el2 == other.el2
+                && groupIDs.EqualsUnordered(other.groupIDs)
+                && EqualsObjectID(other)
+                && X == other.X
+                && Y == other.Y
+                && rotation == other.rotation
+                && scaling == other.scaling
+                && LinkedGroupID == other.LinkedGroupID
+                && zLayer == other.zLayer
+                && ZOrder == other.ZOrder;
+        }
+        /// <summary>Useful for inherited objects' property hiding.</summary>
+        /// <param name="other">The other object to compare the object ID with.</param>
+        protected virtual bool EqualsObjectID(GeneralObject other) => objectID == other.objectID;
+        /// <summary>Determines whether this <seealso cref="GeneralObject"/> equals another <seealso cref="GeneralObject"/>.</summary>
+        /// <param name="other">The other <seealso cref="GeneralObject"/> to check equality against.</param>
+        public bool Equals(GeneralObject other) => EqualsInherited(other);
+        /// <summary>Determines whether this object equals another object. Not recommended using at all due to performance issues and overgeneralization of the implementation.</summary>
+        /// <param name="obj">The other object to check equality against.</param>
+        public override bool Equals(object obj) => Equals(obj as GeneralObject);
+
+        public static bool operator ==(GeneralObject left, GeneralObject right) => left.Equals(right);
+        public static bool operator !=(GeneralObject left, GeneralObject right) => !left.Equals(right);
+
         /// <summary>Returns a new instance of the appropriate class of an object based on its object ID.</summary>
         /// <param name="objectID">The object ID of the new object.</param>
         public static GeneralObject GetNewObjectInstance(int objectID)

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
@@ -222,26 +222,20 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
         /// <param name="cloned">The cloned instance to add the information to.</param>
         protected virtual GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
-            cloned.ObjectID = ObjectID;
+            cloned.objectID = objectID;
             cloned.X = X;
             cloned.Y = Y;
-            cloned.FlippedHorizontally = FlippedHorizontally;
-            cloned.FlippedVertically = FlippedVertically;
-            cloned.Rotation = Rotation;
-            cloned.Scaling = Scaling;
-            cloned.EL1 = EL1;
-            cloned.EL2 = EL2;
-            cloned.ZLayer = ZLayer;
-            cloned.ZOrder = ZOrder;
-            cloned.Color1ID = Color1ID;
-            cloned.Color2ID = Color2ID;
-            cloned.GroupIDs = GroupIDs;
+            cloned.bools = bools; // Prefer one assignment, compared to 7 property assignments
+            cloned.rotation = rotation;
+            cloned.scaling = scaling;
+            cloned.el1 = el1;
+            cloned.el2 = el2;
+            cloned.zLayer = zLayer;
+            cloned.zOrder = zOrder;
+            cloned.color1ID = color1ID;
+            cloned.color2ID = color2ID;
+            cloned.groupIDs = groupIDs.CopyArray();
             cloned.LinkedGroupID = LinkedGroupID;
-            cloned.GroupParent = GroupParent;
-            cloned.HighDetail = HighDetail;
-            cloned.DontEnter = DontEnter;
-            cloned.DontFade = DontFade;
-            cloned.DisableGlow = DisableGlow;
             return cloned;
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
@@ -266,18 +266,19 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
         /// <param name="endingY">The ending Y position of the rectangle.</param>
         public bool IsWithinRange(double startingX, double startingY, double endingX, double endingY) => startingX <= X && endingX >= X && startingY <= Y && endingY >= Y;
 
-        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function before returning the result. That means an <see langword="override"/> should look like <see langword="return"/> ... &amp;&amp; <see langword="base"/>.EqualsInherited(<paramref name="other"/>);.</summary>
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
         /// <param name="other">The other object to check whether it equals this object's properties.</param>
         protected virtual bool EqualsInherited(GeneralObject other)
         {
             // Seriously I do not like how this looks, but at least there is some symmetry, which is the most I could think of
-            return bools == other.bools
+            return EqualsType(other)
+                && bools == other.bools
                 && color1ID == other.color1ID
                 && color2ID == other.color2ID
                 && el1 == other.el1
                 && el2 == other.el2
                 && groupIDs.EqualsUnordered(other.groupIDs)
-                && EqualsObjectID(other)
+                && objectID == other.objectID
                 && X == other.X
                 && Y == other.Y
                 && rotation == other.rotation
@@ -286,9 +287,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
                 && zLayer == other.zLayer
                 && ZOrder == other.ZOrder;
         }
-        /// <summary>Useful for inherited objects' property hiding.</summary>
-        /// <param name="other">The other object to compare the object ID with.</param>
-        protected virtual bool EqualsObjectID(GeneralObject other) => objectID == other.objectID;
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected virtual bool EqualsType(GeneralObject other) => true;
         /// <summary>Determines whether this <seealso cref="GeneralObject"/> equals another <seealso cref="GeneralObject"/>.</summary>
         /// <param name="other">The other <seealso cref="GeneralObject"/> to check equality against.</param>
         public bool Equals(GeneralObject other) => EqualsInherited(other);

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
@@ -271,14 +271,13 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
         protected virtual bool EqualsInherited(GeneralObject other)
         {
             // Seriously I do not like how this looks, but at least there is some symmetry, which is the most I could think of
-            return EqualsType(other)
+            return objectID == other.objectID
                 && bools == other.bools
                 && color1ID == other.color1ID
                 && color2ID == other.color2ID
                 && el1 == other.el1
                 && el2 == other.el2
                 && groupIDs.EqualsUnordered(other.groupIDs)
-                && objectID == other.objectID
                 && X == other.X
                 && Y == other.Y
                 && rotation == other.rotation
@@ -287,7 +286,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
                 && zLayer == other.zLayer
                 && ZOrder == other.ZOrder;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <summary>Determines whether this object's type is the same as another object's type. Probably will have to discard, as object ID automatically determines object type.</summary>
         /// <param name="other">The other object to check whether its type is the same as this one's.</param>
         protected virtual bool EqualsType(GeneralObject other) => true;
         /// <summary>Determines whether this <seealso cref="GeneralObject"/> equals another <seealso cref="GeneralObject"/>.</summary>

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
@@ -286,9 +286,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
                 && zLayer == other.zLayer
                 && ZOrder == other.ZOrder;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type. Probably will have to discard, as object ID automatically determines object type.</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected virtual bool EqualsType(GeneralObject other) => true;
         /// <summary>Determines whether this <seealso cref="GeneralObject"/> equals another <seealso cref="GeneralObject"/>.</summary>
         /// <param name="other">The other <seealso cref="GeneralObject"/> to check equality against.</param>
         public bool Equals(GeneralObject other) => EqualsInherited(other);

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/GeneralObject.cs
@@ -315,7 +315,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects
             cloned.color1ID = color1ID;
             cloned.color2ID = color2ID;
             cloned.groupIDs = groupIDs.CopyArray();
-            cloned.LinkedGroupID = LinkedGroupID
+            cloned.LinkedGroupID = LinkedGroupID;
             cloned.transformationScalingX = transformationScalingX;
             cloned.transformationScalingY = transformationScalingY;
             cloned.transformationScalingCenterX = transformationScalingCenterX;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/AnimatedObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/AnimatedObject.cs
@@ -32,9 +32,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
 
         /// <summary>Returns a clone of this <seealso cref="AnimatedObject"/>.</summary>
         public override GeneralObject Clone() => AddClonedInstanceInformation(new AnimatedObject());
-
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is AnimatedObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/AnimatedObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/AnimatedObject.cs
@@ -32,5 +32,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
 
         /// <summary>Returns a clone of this <seealso cref="AnimatedObject"/>.</summary>
         public override GeneralObject Clone() => AddClonedInstanceInformation(new AnimatedObject());
+
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is AnimatedObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CollisionBlock.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CollisionBlock.cs
@@ -49,8 +49,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as CollisionBlock;
-            c.BlockID = BlockID;
-            c.DynamicBlock = DynamicBlock;
+            c.blockID = blockID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CollisionBlock.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CollisionBlock.cs
@@ -53,5 +53,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             c.DynamicBlock = DynamicBlock;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as CollisionBlock;
+            return base.EqualsInherited(other)
+                && blockID == z.blockID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is CollisionBlock;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CollisionBlock.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CollisionBlock.cs
@@ -61,8 +61,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             return base.EqualsInherited(other)
                 && blockID == z.blockID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is CollisionBlock;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CountTextObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CountTextObject.cs
@@ -42,7 +42,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as CountTextObject;
-            c.ItemID = ItemID;
+            c.itemID = itemID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CountTextObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CountTextObject.cs
@@ -45,5 +45,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             c.ItemID = ItemID;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as CountTextObject;
+            return base.EqualsInherited(other)
+                && itemID == z.itemID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is CountTextObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CountTextObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CountTextObject.cs
@@ -54,8 +54,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             return base.EqualsInherited(other)
                 && itemID == z.itemID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is CountTextObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CustomParticleObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CustomParticleObject.cs
@@ -483,8 +483,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
                 && AreEqual(start, z.start)
                 && AreEqual(end, z.end);
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is CustomParticleObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CustomParticleObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CustomParticleObject.cs
@@ -435,9 +435,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             var c = cloned as CustomParticleObject;
             c.Grouping = Grouping;
             c.Property1 = Property1;
-            c.MaxParticles = MaxParticles;
-            c.Duration = Duration;
-            c.Emission = Emission;
+            c.maxParticles = maxParticles;
+            c.duration = duration;
+            c.emission = emission;
             c.posVar = posVar;
             c.gravity = gravity;
             c.startSize = startSize;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CustomParticleObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/CustomParticleObject.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static GDEdit.Utilities.Objects.General.SymmetricalRangeMethods;
 
 namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
 {
@@ -454,5 +455,36 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             c.end = end;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as CustomParticleObject;
+            return base.EqualsInherited(other)
+                && Grouping == z.Grouping
+                && Property1 == z.Property1
+                && maxParticles == z.maxParticles
+                && duration == z.duration
+                && emission == z.emission
+                && posVar == z.posVar
+                && gravity == z.gravity
+                && AreEqual(startSize, z.startSize)
+                && AreEqual(endSize, z.endSize)
+                && AreEqual(startSpin, z.startSpin)
+                && AreEqual(endSpin, z.endSpin)
+                && AreEqual(lifetime, z.lifetime)
+                && AreEqual(angle, z.angle)
+                && AreEqual(speed, z.speed)
+                && AreEqual(accelRad, z.accelRad)
+                && AreEqual(accelTan, z.accelTan)
+                && AreEqual(fadeIn, z.fadeIn)
+                && AreEqual(fadeOut, z.fadeOut)
+                && AreEqual(start, z.start)
+                && AreEqual(end, z.end);
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is CustomParticleObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/Orb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/Orb.cs
@@ -23,14 +23,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
 
         /// <summary>Initializes a new instance of the <seealso cref="Orb"/> class.</summary>
         public Orb() : base() { }
-
-        /// <summary>Adds the cloned instance information and returns the cloned instance.</summary>
-        /// <param name="cloned">The cloned instance to add the information to.</param>
-        protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
-        {
-            var c = cloned as Orb;
-            c.MultiActivate = MultiActivate;
-            return base.AddClonedInstanceInformation(c);
-        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/TriggerOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/TriggerOrb.cs
@@ -45,8 +45,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as TriggerOrb;
-            c.TargetGroupID = TargetGroupID;
-            c.ActivateGroup = ActivateGroup;
+            c.targetGroupID = targetGroupID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/TriggerOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/TriggerOrb.cs
@@ -49,5 +49,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
             c.ActivateGroup = ActivateGroup;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as TriggerOrb;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is TriggerOrb;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/TriggerOrb.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Orbs/TriggerOrb.cs
@@ -57,8 +57,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Orbs
             return base.EqualsInherited(other)
                 && targetGroupID == z.targetGroupID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is TriggerOrb;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PickupItem.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PickupItem.cs
@@ -88,8 +88,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
                 && targetItemID == z.targetItemID
                 && targetGroupID == z.targetGroupID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is PickupItem;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PickupItem.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PickupItem.cs
@@ -79,5 +79,19 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             c.EnableGroup = EnableGroup;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as PickupItem;
+            return base.EqualsInherited(other)
+                && PickupMode == z.PickupMode
+                && targetItemID == z.targetItemID
+                && targetGroupID == z.targetGroupID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is PickupItem;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PickupItem.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PickupItem.cs
@@ -73,10 +73,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
         {
             var c = cloned as PickupItem;
             c.PickupMode = PickupMode;
-            c.TargetItemID = TargetItemID;
-            c.SubtractCount = SubtractCount;
-            c.TargetGroupID = TargetGroupID;
-            c.EnableGroup = EnableGroup;
+            c.targetItemID = targetItemID;
+            c.targetGroupID = targetGroupID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueTeleportationPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueTeleportationPortal.cs
@@ -58,8 +58,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
                 && YellowTeleportationPortalDistance == z.YellowTeleportationPortalDistance
                 && LinkedYellowTeleportationPortal == z.LinkedYellowTeleportationPortal;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is BlueTeleportationPortal;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueTeleportationPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/BlueTeleportationPortal.cs
@@ -48,5 +48,18 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
             c.YellowTeleportationPortalDistance = YellowTeleportationPortalDistance;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as BlueTeleportationPortal;
+            return base.EqualsInherited(other)
+                && YellowTeleportationPortalDistance == z.YellowTeleportationPortalDistance
+                && LinkedYellowTeleportationPortal == z.LinkedYellowTeleportationPortal;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is BlueTeleportationPortal;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/BallPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/BallPortal.cs
@@ -31,14 +31,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
 
         /// <summary>Returns a clone of this <seealso cref="BallPortal"/>.</summary>
         public override GeneralObject Clone() => AddClonedInstanceInformation(new BallPortal());
-
-        /// <summary>Adds the cloned instance information and returns the cloned instance.</summary>
-        /// <param name="cloned">The cloned instance to add the information to.</param>
-        protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
-        {
-            var c = cloned as BallPortal;
-            c.Checked = Checked;
-            return base.AddClonedInstanceInformation(c);
-        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/ShipPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/ShipPortal.cs
@@ -31,14 +31,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
 
         /// <summary>Returns a clone of this <seealso cref="ShipPortal"/>.</summary>
         public override GeneralObject Clone() => AddClonedInstanceInformation(new ShipPortal());
-
-        /// <summary>Adds the cloned instance information and returns the cloned instance.</summary>
-        /// <param name="cloned">The cloned instance to add the information to.</param>
-        protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
-        {
-            var c = cloned as ShipPortal;
-            c.Checked = Checked;
-            return base.AddClonedInstanceInformation(c);
-        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/SpiderPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/SpiderPortal.cs
@@ -31,14 +31,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
 
         /// <summary>Returns a clone of this <seealso cref="SpiderPortal"/>.</summary>
         public override GeneralObject Clone() => AddClonedInstanceInformation(new SpiderPortal());
-
-        /// <summary>Adds the cloned instance information and returns the cloned instance.</summary>
-        /// <param name="cloned">The cloned instance to add the information to.</param>
-        protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
-        {
-            var c = cloned as SpiderPortal;
-            c.Checked = Checked;
-            return base.AddClonedInstanceInformation(c);
-        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/UFOPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/UFOPortal.cs
@@ -31,14 +31,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
 
         /// <summary>Returns a clone of this <seealso cref="UFOPortal"/>.</summary>
         public override GeneralObject Clone() => AddClonedInstanceInformation(new UFOPortal());
-
-        /// <summary>Adds the cloned instance information and returns the cloned instance.</summary>
-        /// <param name="cloned">The cloned instance to add the information to.</param>
-        protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
-        {
-            var c = cloned as UFOPortal;
-            c.Checked = Checked;
-            return base.AddClonedInstanceInformation(c);
-        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/WavePortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/GamemodePortals/WavePortal.cs
@@ -31,14 +31,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
 
         /// <summary>Returns a clone of this <seealso cref="WavePortal"/>.</summary>
         public override GeneralObject Clone() => AddClonedInstanceInformation(new WavePortal());
-
-        /// <summary>Adds the cloned instance information and returns the cloned instance.</summary>
-        /// <param name="cloned">The cloned instance to add the information to.</param>
-        protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
-        {
-            var c = cloned as WavePortal;
-            c.Checked = Checked;
-            return base.AddClonedInstanceInformation(c);
-        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/SpeedPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/SpeedPortals/SpeedPortal.cs
@@ -28,14 +28,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
         {
             Checked = true;
         }
-
-        /// <summary>Adds the cloned instance information and returns the cloned instance.</summary>
-        /// <param name="cloned">The cloned instance to add the information to.</param>
-        protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
-        {
-            var c = cloned as SpeedPortal;
-            c.Checked = Checked;
-            return base.AddClonedInstanceInformation(c);
-        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowTeleportationPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowTeleportationPortal.cs
@@ -34,6 +34,11 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
         /// <summary>Returns a clone of this <seealso cref="YellowTeleportationPortal"/>.</summary>
         public override GeneralObject Clone() => new YellowTeleportationPortal(LinkedTeleportationPortal);
 
+        // Do not override EqualsInherited to avoid recursion when comparing the parent blue teleportation portal
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is YellowTeleportationPortal;
+
         /// <summary>Sets the properties of this <seealso cref="YellowTeleportationPortal"/> according to the linked <seealso cref="BlueTeleportationPortal"/>.</summary>
         private void SetProperties(BlueTeleportationPortal a)
         {

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowTeleportationPortal.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/Portals/YellowTeleportationPortal.cs
@@ -35,9 +35,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects.Port
         public override GeneralObject Clone() => new YellowTeleportationPortal(LinkedTeleportationPortal);
 
         // Do not override EqualsInherited to avoid recursion when comparing the parent blue teleportation portal
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is YellowTeleportationPortal;
 
         /// <summary>Sets the properties of this <seealso cref="YellowTeleportationPortal"/> according to the linked <seealso cref="BlueTeleportationPortal"/>.</summary>
         private void SetProperties(BlueTeleportationPortal a)

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
@@ -61,8 +61,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             return base.EqualsInherited(other)
                 && AnimationSpeed == z.AnimationSpeed;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is PulsatingObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
@@ -53,5 +53,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             c.RandomizeStart = RandomizeStart;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as PulsatingObject;
+            return base.EqualsInherited(other)
+                && AnimationSpeed == z.AnimationSpeed;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is PulsatingObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/PulsatingObject.cs
@@ -50,7 +50,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
         {
             var c = cloned as PulsatingObject;
             c.AnimationSpeed = AnimationSpeed;
-            c.RandomizeStart = RandomizeStart;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/RotatingObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/RotatingObject.cs
@@ -48,5 +48,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             c.DisableRotation = DisableRotation;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is RotatingObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/RotatingObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/RotatingObject.cs
@@ -39,9 +39,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
 
         /// <summary>Returns a clone of this <seealso cref="RotatingObject"/>.</summary>
         public override GeneralObject Clone() => AddClonedInstanceInformation(new RotatingObject());
-
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is RotatingObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/RotatingObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/RotatingObject.cs
@@ -40,15 +40,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
         /// <summary>Returns a clone of this <seealso cref="RotatingObject"/>.</summary>
         public override GeneralObject Clone() => AddClonedInstanceInformation(new RotatingObject());
 
-        /// <summary>Adds the cloned instance information and returns the cloned instance.</summary>
-        /// <param name="cloned">The cloned instance to add the information to.</param>
-        protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
-        {
-            var c = cloned as RotatingObject;
-            c.DisableRotation = DisableRotation;
-            return base.AddClonedInstanceInformation(c);
-        }
-
         /// <summary>Determines whether this object's type is the same as another object's type</summary>
         /// <param name="other">The other object to check whether its type is the same as this one's.</param>
         protected override bool EqualsType(GeneralObject other) => other is RotatingObject;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
@@ -34,7 +34,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
                 throw new InvalidCastException($"This object ID does not represent a valid {SpecialObjectTypeName}.");
         }
 
-        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function before returning the result. That means an <see langword="override"/> should look like <see langword="return"/> ... &amp;&amp; <see langword="base"/>.EqualsInherited(<paramref name="other"/>);.</summary>
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
         /// <param name="other">The other object to check whether it equals this object's properties.</param>
         protected override bool EqualsInherited(GeneralObject other)
         {

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
@@ -34,6 +34,15 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
                 throw new InvalidCastException($"This object ID does not represent a valid {SpecialObjectTypeName}.");
         }
 
+        /// <summary>Adds the cloned instance information and returns the cloned instance.</summary>
+        /// <param name="cloned">The cloned instance to add the information to.</param>
+        protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
+        {
+            var c = cloned as SpecialObject;
+            c.SpecialObjectBools = SpecialObjectBools;
+            return base.AddClonedInstanceInformation(c);
+        }
+
         /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
         /// <param name="other">The other object to check whether it equals this object's properties.</param>
         protected override bool EqualsInherited(GeneralObject other)

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/SpecialObject.cs
@@ -33,5 +33,13 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             if (!ValidObjectIDs.Contains(objectID))
                 throw new InvalidCastException($"This object ID does not represent a valid {SpecialObjectTypeName}.");
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function before returning the result. That means an <see langword="override"/> should look like <see langword="return"/> ... &amp;&amp; <see langword="base"/>.EqualsInherited(<paramref name="other"/>);.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            return SpecialObjectBools == (other as SpecialObject).SpecialObjectBools
+                && base.EqualsInherited(other);
+        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/TextObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/TextObject.cs
@@ -49,5 +49,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             c.Text = Text;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as TextObject;
+            return base.EqualsInherited(other)
+                && Text == z.Text;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is TextObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/TextObject.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/SpecialObjects/TextObject.cs
@@ -58,8 +58,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.SpecialObjects
             return base.EqualsInherited(other)
                 && Text == z.Text;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is TextObject;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
@@ -63,9 +63,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as AlphaTrigger;
-            c.Duration = Duration;
-            c.TargetGroupID = TargetGroupID;
-            c.Opacity = Opacity;
+            c.duration = duration;
+            c.targetGroupID = targetGroupID;
+            c.opacity = opacity;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
@@ -68,5 +68,19 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.Opacity = Opacity;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as AlphaTrigger;
+            return base.EqualsInherited(other)
+                && duration == z.duration
+                && targetGroupID == z.targetGroupID
+                && opacity == z.opacity;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is AlphaTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AlphaTrigger.cs
@@ -79,8 +79,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && targetGroupID == z.targetGroupID
                 && opacity == z.opacity;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is AlphaTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
@@ -68,8 +68,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && animationID == z.animationID
                 && targetGroupID == z.targetGroupID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is AnimateTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
@@ -58,5 +58,18 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.TargetGroupID = TargetGroupID;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as AnimateTrigger;
+            return base.EqualsInherited(other)
+                && animationID == z.animationID
+                && targetGroupID == z.targetGroupID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is AnimateTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/AnimateTrigger.cs
@@ -54,8 +54,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as AnimateTrigger;
-            c.AnimationID = AnimationID;
-            c.TargetGroupID = TargetGroupID;
+            c.animationID = animationID;
+            c.targetGroupID = targetGroupID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CameraOffsetTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CameraOffsetTrigger.cs
@@ -109,8 +109,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && offsetY == z.offsetY
                 && TargetPosCoordinates == z.TargetPosCoordinates;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is CameraOffsetTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CameraOffsetTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CameraOffsetTrigger.cs
@@ -87,11 +87,11 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as CameraOffsetTrigger;
-            c.Duration = Duration;
+            c.duration = duration;
             c.Easing = Easing;
-            c.EasingRate = EasingRate;
-            c.OffsetX = OffsetX;
-            c.OffsetY = OffsetY;
+            c.easingRate = easingRate;
+            c.offsetX = offsetX;
+            c.offsetY = offsetY;
             c.TargetPosCoordinates = TargetPosCoordinates;
             return base.AddClonedInstanceInformation(c);
         }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CameraOffsetTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CameraOffsetTrigger.cs
@@ -95,5 +95,22 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.TargetPosCoordinates = TargetPosCoordinates;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as CameraOffsetTrigger;
+            return base.EqualsInherited(other)
+                && duration == z.duration
+                && Easing == z.Easing
+                && easingRate == z.easingRate
+                && offsetX == z.offsetX
+                && offsetY == z.offsetY
+                && TargetPosCoordinates == z.TargetPosCoordinates;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is CameraOffsetTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
@@ -87,5 +87,19 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.TriggerOnExit = TriggerOnExit;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as CollisionTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID
+                && primaryBlockID == z.primaryBlockID
+                && secondaryBlockID == z.secondaryBlockID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is CollisionTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
@@ -96,8 +96,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && primaryBlockID == z.primaryBlockID
                 && secondaryBlockID == z.secondaryBlockID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is CollisionTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CollisionTrigger.cs
@@ -80,11 +80,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as CollisionTrigger;
-            c.TargetGroupID = TargetGroupID;
-            c.PrimaryBlockID = PrimaryBlockID;
-            c.SecondaryBlockID = SecondaryBlockID;
-            c.ActivateGroup = ActivateGroup;
-            c.TriggerOnExit = TriggerOnExit;
+            c.targetGroupID = targetGroupID;
+            c.primaryBlockID = primaryBlockID;
+            c.secondaryBlockID = secondaryBlockID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
@@ -157,8 +157,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && CopiedColorID == z.CopiedColorID
                 && HSVAdjustment == z.HSVAdjustment;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is ColorTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
@@ -144,5 +144,23 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.HSVAdjustment = HSVAdjustment;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as ColorTrigger;
+            return base.EqualsInherited(other)
+                && targetColorID == z.targetColorID
+                && red == z.red
+                && green == z.green
+                && blue == z.blue
+                && opacity == z.opacity
+                && CopiedColorID == z.CopiedColorID
+                && HSVAdjustment == z.HSVAdjustment;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is ColorTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ColorTrigger.cs
@@ -131,16 +131,13 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as ColorTrigger;
-            c.TargetColorID = TargetColorID;
-            c.Duration = Duration;
-            c.Red = Red;
-            c.Green = Green;
-            c.Blue = Blue;
-            c.Opacity = Opacity;
+            c.targetColorID = targetColorID;
+            c.duration = duration;
+            c.red = red;
+            c.green = green;
+            c.blue = blue;
+            c.opacity = opacity;
             c.CopiedColorID = CopiedColorID;
-            c.Blending = Blending;
-            c.CopyOpacity = CopyOpacity;
-            c.TintGround = TintGround;
             c.HSVAdjustment = HSVAdjustment;
             return base.AddClonedInstanceInformation(c);
         }
@@ -152,6 +149,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             var z = other as ColorTrigger;
             return base.EqualsInherited(other)
                 && targetColorID == z.targetColorID
+                && duration == z.duration
                 && red == z.red
                 && green == z.green
                 && blue == z.blue

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CountTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CountTrigger.cs
@@ -83,11 +83,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as CountTrigger;
-            c.TargetGroupID = TargetGroupID;
-            c.ItemID = ItemID;
+            c.targetGroupID = targetGroupID;
+            c.itemID = itemID;
             c.TargetCount = TargetCount;
-            c.ActivateGroup = ActivateGroup;
-            c.MultiActivate = MultiActivate;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CountTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CountTrigger.cs
@@ -90,5 +90,19 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.MultiActivate = MultiActivate;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as CountTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID
+                && itemID == z.itemID
+                && TargetCount == z.TargetCount;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is CountTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CountTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/CountTrigger.cs
@@ -99,8 +99,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && itemID == z.itemID
                 && TargetCount == z.TargetCount;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is CountTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/EndTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/EndTrigger.cs
@@ -67,5 +67,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.LockY = LockY;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as EndTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is EndTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/EndTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/EndTrigger.cs
@@ -62,9 +62,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as EndTrigger;
-            c.TargetGroupID = TargetGroupID;
-            c.Reversed = Reversed;
-            c.LockY = LockY;
+            c.targetGroupID = targetGroupID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/EndTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/EndTrigger.cs
@@ -74,8 +74,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             return base.EqualsInherited(other)
                 && targetGroupID == z.targetGroupID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is EndTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
@@ -115,8 +115,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && maxSpeed == z.maxSpeed
                 && Offset == z.Offset;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is FollowPlayerYTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
@@ -101,5 +101,22 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.Offset = Offset;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as FollowPlayerYTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID
+                && duration == z.duration
+                && speed == z.speed
+                && delay == z.delay
+                && maxSpeed == z.maxSpeed
+                && Offset == z.Offset;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is FollowPlayerYTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowPlayerYTrigger.cs
@@ -93,11 +93,11 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as FollowPlayerYTrigger;
-            c.Duration = Duration;
-            c.TargetGroupID = TargetGroupID;
-            c.Speed = Speed;
-            c.Delay = Delay;
-            c.MaxSpeed = MaxSpeed;
+            c.targetGroupID = targetGroupID;
+            c.duration = duration;
+            c.speed = speed;
+            c.delay = delay;
+            c.maxSpeed = maxSpeed;
             c.Offset = Offset;
             return base.AddClonedInstanceInformation(c);
         }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
@@ -100,5 +100,21 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.YMod = YMod;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as FollowTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID
+                && duration == z.duration
+                && xMod == z.xMod
+                && yMod == z.yMod
+                && followGroupID == z.followGroupID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is FollowTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
@@ -113,8 +113,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && yMod == z.yMod
                 && followGroupID == z.followGroupID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is FollowTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/FollowTrigger.cs
@@ -93,11 +93,11 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as FollowTrigger;
-            c.Duration = Duration;
-            c.TargetGroupID = TargetGroupID;
-            c.FollowGroupID = FollowGroupID;
-            c.XMod = XMod;
-            c.YMod = YMod;
+            c.targetGroupID = targetGroupID;
+            c.duration = duration;
+            c.xMod = xMod;
+            c.yMod = yMod;
+            c.followGroupID = followGroupID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/InstantCountTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/InstantCountTrigger.cs
@@ -79,10 +79,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as InstantCountTrigger;
-            c.TargetGroupID = TargetGroupID;
-            c.ItemID = ItemID;
+            c.targetGroupID = targetGroupID;
+            c.itemID = itemID;
             c.TargetCount = TargetCount;
-            c.ActivateGroup = ActivateGroup;
             c.Comparison = Comparison;
             return base.AddClonedInstanceInformation(c);
         }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/InstantCountTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/InstantCountTrigger.cs
@@ -86,5 +86,20 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.Comparison = Comparison;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as InstantCountTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID
+                && itemID == z.itemID
+                && TargetCount == z.TargetCount
+                && Comparison == z.Comparison;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is InstantCountTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/InstantCountTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/InstantCountTrigger.cs
@@ -97,8 +97,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && TargetCount == z.TargetCount
                 && Comparison == z.Comparison;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is InstantCountTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/MoveTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/MoveTrigger.cs
@@ -167,8 +167,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && moveY == z.moveY
                 && TargetPosCoordinates == z.TargetPosCoordinates;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is MoveTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/MoveTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/MoveTrigger.cs
@@ -142,15 +142,13 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as MoveTrigger;
-            c.Duration = Duration;
-            c.TargetGroupID = TargetGroupID;
+            c.targetGroupID = targetGroupID;
+            c.duration = duration;
             c.TargetPosGroupID = TargetPosGroupID;
             c.Easing = Easing;
-            c.EasingRate = EasingRate;
-            c.MoveX = MoveX;
-            c.MoveY = MoveY;
-            c.LockToPlayerX = LockToPlayerX;
-            c.LockToPlayerY = LockToPlayerY;
+            c.easingRate = easingRate;
+            c.moveX = moveX;
+            c.moveY = moveY;
             c.TargetPosCoordinates = TargetPosCoordinates;
             return base.AddClonedInstanceInformation(c);
         }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/MoveTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/MoveTrigger.cs
@@ -154,5 +154,23 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.TargetPosCoordinates = TargetPosCoordinates;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as MoveTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID
+                && duration == z.duration
+                && Easing == z.Easing
+                && easingRate == z.easingRate
+                && moveX == z.moveX
+                && moveY == z.moveY
+                && TargetPosCoordinates == z.TargetPosCoordinates;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is MoveTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/OnDeathTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/OnDeathTrigger.cs
@@ -57,5 +57,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.TargetGroupID = TargetGroupID;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as OnDeathTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is OnDeathTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/OnDeathTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/OnDeathTrigger.cs
@@ -65,8 +65,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             return base.EqualsInherited(other)
                 && targetGroupID == z.targetGroupID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is OnDeathTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/OnDeathTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/OnDeathTrigger.cs
@@ -53,8 +53,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as OnDeathTrigger;
-            c.ActivateGroup = ActivateGroup;
-            c.TargetGroupID = TargetGroupID;
+            c.targetGroupID = targetGroupID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PickupTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PickupTrigger.cs
@@ -53,5 +53,18 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.Count = Count;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as PickupTrigger;
+            return base.EqualsInherited(other)
+                && targetItemID == z.targetItemID
+                && Count == z.Count;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is PickupTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PickupTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PickupTrigger.cs
@@ -49,7 +49,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as PickupTrigger;
-            c.TargetItemID = TargetItemID;
+            c.targetItemID = targetItemID;
             c.Count = Count;
             return base.AddClonedInstanceInformation(c);
         }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PickupTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PickupTrigger.cs
@@ -63,8 +63,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && targetItemID == z.targetItemID
                 && Count == z.Count;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is PickupTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
@@ -169,8 +169,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && PulseTargetType == z.PulseTargetType
                 && HSVAdjustment == z.HSVAdjustment;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is PulseTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
@@ -150,5 +150,28 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.HSVAdjustment = HSVAdjustment;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as PulseTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID
+                && targetColorID == z.targetColorID
+                && red == z.red
+                && green == z.green
+                && blue == z.blue
+                && fadeIn == z.fadeIn
+                && hold == z.hold
+                && fadeOut == z.fadeOut
+                && CopiedColorID == z.CopiedColorID
+                && PulseMode == z.PulseMode
+                && PulseTargetType == z.PulseTargetType
+                && HSVAdjustment == z.HSVAdjustment;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is PulseTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/PulseTrigger.cs
@@ -135,18 +135,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as PulseTrigger;
-            c.TargetGroupID = TargetGroupID;
-            c.TargetColorID = TargetColorID;
-            c.Red = Red;
-            c.Green = Green;
-            c.Blue = Blue;
-            c.FadeIn = FadeIn;
-            c.Hold = Hold;
-            c.FadeOut = FadeOut;
+            c.targetGroupID = targetGroupID;
+            c.targetColorID = targetColorID;
+            c.red = red;
+            c.green = green;
+            c.blue = blue;
+            c.fadeIn = fadeIn;
+            c.hold = hold;
+            c.fadeOut = fadeOut;
             c.CopiedColorID = CopiedColorID;
             c.PulseMode = PulseMode;
             c.PulseTargetType = PulseTargetType;
-            c.Exclusive = Exclusive;
             c.HSVAdjustment = HSVAdjustment;
             return base.AddClonedInstanceInformation(c);
         }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RandomTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RandomTrigger.cs
@@ -94,5 +94,19 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.ActivateGroup = ActivateGroup;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as RandomTrigger;
+            return base.EqualsInherited(other)
+                && groupID1 == z.groupID1
+                && groupID2 == z.groupID2
+                && chance == z.chance;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is RandomTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RandomTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RandomTrigger.cs
@@ -88,10 +88,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as RandomTrigger;
-            c.GroupID1 = GroupID1;
-            c.GroupID2 = GroupID2;
-            c.Chance = Chance;
-            c.ActivateGroup = ActivateGroup;
+            c.groupID1 = groupID1;
+            c.groupID2 = groupID2;
+            c.chance = chance;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RandomTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RandomTrigger.cs
@@ -104,8 +104,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && groupID2 == z.groupID2
                 && chance == z.chance;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is RandomTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ReverseTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ReverseTrigger.cs
@@ -34,15 +34,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         /// <summary>Returns a clone of this <seealso cref="ReverseTrigger"/>.</summary>
         public override GeneralObject Clone() => AddClonedInstanceInformation(new ReverseTrigger());
 
-        /// <summary>Adds the cloned instance information and returns the cloned instance.</summary>
-        /// <param name="cloned">The cloned instance to add the information to.</param>
-        protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
-        {
-            var c = cloned as ReverseTrigger;
-            c.Reverse = Reverse;
-            return base.AddClonedInstanceInformation(c);
-        }
-
         /// <summary>Determines whether this object's type is the same as another object's type</summary>
         /// <param name="other">The other object to check whether its type is the same as this one's.</param>
         protected override bool EqualsType(GeneralObject other) => other is ReverseTrigger;

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ReverseTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ReverseTrigger.cs
@@ -33,9 +33,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
 
         /// <summary>Returns a clone of this <seealso cref="ReverseTrigger"/>.</summary>
         public override GeneralObject Clone() => AddClonedInstanceInformation(new ReverseTrigger());
-
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is ReverseTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ReverseTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ReverseTrigger.cs
@@ -42,5 +42,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.Reverse = Reverse;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is ReverseTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RotateTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RotateTrigger.cs
@@ -130,5 +130,23 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.CenterGroupID = CenterGroupID;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as RotateTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID
+                && duration == z.duration
+                && Easing == z.Easing
+                && easingRate == z.easingRate
+                && Degrees == z.Degrees
+                && Times360 == z.Times360
+                && centerGroupID == z.centerGroupID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is RotateTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RotateTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RotateTrigger.cs
@@ -143,8 +143,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && Times360 == z.Times360
                 && centerGroupID == z.centerGroupID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is RotateTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RotateTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/RotateTrigger.cs
@@ -119,15 +119,13 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as RotateTrigger;
-            c.Duration = Duration;
-            c.TargetGroupID = TargetGroupID;
-            c.CenterGroupID = CenterGroupID;
+            c.targetGroupID = targetGroupID;
+            c.duration = duration;
             c.Easing = Easing;
-            c.EasingRate = EasingRate;
+            c.easingRate = easingRate;
             c.Degrees = Degrees;
             c.Times360 = Times360;
-            c.LockObjectRotation = LockObjectRotation;
-            c.CenterGroupID = CenterGroupID;
+            c.centerGroupID = centerGroupID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ScaleTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ScaleTrigger.cs
@@ -129,8 +129,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && scalingMultiplier == z.scalingMultiplier
                 && centerGroupID == z.centerGroupID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is ScaleTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ScaleTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ScaleTrigger.cs
@@ -113,8 +113,24 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.Easing = Easing;
             c.EasingRate = EasingRate;
             c.ScalingMultiplier = ScalingMultiplier;
-            c.CenterGroupID = CenterGroupID;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as ScaleTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID
+                && duration == z.duration
+                && Easing == z.Easing
+                && easingRate == z.easingRate
+                && scalingMultiplier == z.scalingMultiplier
+                && centerGroupID == z.centerGroupID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is ScaleTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ScaleTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ScaleTrigger.cs
@@ -132,7 +132,6 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.duration = duration;
             c.Easing = Easing;
             c.easingRate = easingRate;
-            c.scalingMultiplier = scalingMultiplier;
             c.scaleX = scaleX;
             c.scaleY = scaleY;
             c.centerGroupID = centerGroupID;
@@ -149,7 +148,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && duration == z.duration
                 && Easing == z.Easing
                 && easingRate == z.easingRate
-                && scalingMultiplier == z.scalingMultiplier
+                && scaleX == z.scaleX
+                && scaleY == z.scaleY
                 && centerGroupID == z.centerGroupID;
         }
     }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ScaleTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ScaleTrigger.cs
@@ -107,12 +107,12 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as ScaleTrigger;
-            c.Duration = Duration;
-            c.TargetGroupID = TargetGroupID;
-            c.CenterGroupID = CenterGroupID;
+            c.targetGroupID = targetGroupID;
+            c.duration = duration;
             c.Easing = Easing;
-            c.EasingRate = EasingRate;
-            c.ScalingMultiplier = ScalingMultiplier;
+            c.easingRate = easingRate;
+            c.scalingMultiplier = scalingMultiplier;
+            c.centerGroupID = centerGroupID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ShakeTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ShakeTrigger.cs
@@ -78,8 +78,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && strength == z.strength
                 && interval == z.interval;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is ShakeTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ShakeTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ShakeTrigger.cs
@@ -67,5 +67,19 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.Interval = Interval;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as ShakeTrigger;
+            return base.EqualsInherited(other)
+                && duration == z.duration
+                && strength == z.strength
+                && interval == z.interval;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is ShakeTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ShakeTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ShakeTrigger.cs
@@ -62,9 +62,9 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as ShakeTrigger;
-            c.Duration = Duration;
-            c.Strength = Strength;
-            c.Interval = Interval;
+            c.duration = duration;
+            c.strength = strength;
+            c.interval = interval;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/SpawnTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/SpawnTrigger.cs
@@ -63,9 +63,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as SpawnTrigger;
-            c.TargetGroupID = TargetGroupID;
-            c.Delay = Delay;
-            c.EditorDisable = EditorDisable;
+            c.targetGroupID = targetGroupID;
+            c.delay = delay;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/SpawnTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/SpawnTrigger.cs
@@ -77,8 +77,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && targetGroupID == z.targetGroupID
                 && delay == z.delay;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is SpawnTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/SpawnTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/SpawnTrigger.cs
@@ -68,5 +68,18 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.EditorDisable = EditorDisable;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as SpawnTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID
+                && delay == z.delay;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is SpawnTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StaticCameraTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StaticCameraTrigger.cs
@@ -78,11 +78,10 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as StaticCameraTrigger;
-            c.Duration = Duration;
-            c.TargetGroupID = TargetGroupID;
+            c.targetGroupID = targetGroupID;
+            c.duration = duration;
             c.Easing = Easing;
-            c.EasingRate = EasingRate;
-            c.ExitStatic = ExitStatic;
+            c.easingRate = easingRate;
             c.TargetPosCoordinates = TargetPosCoordinates;
             return base.AddClonedInstanceInformation(c);
         }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StaticCameraTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StaticCameraTrigger.cs
@@ -98,8 +98,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && easingRate == z.easingRate
                 && TargetPosCoordinates == z.TargetPosCoordinates;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is StaticCameraTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StaticCameraTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StaticCameraTrigger.cs
@@ -86,5 +86,21 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.TargetPosCoordinates = TargetPosCoordinates;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as StaticCameraTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID
+                && duration == z.duration
+                && Easing == z.Easing
+                && easingRate == z.easingRate
+                && TargetPosCoordinates == z.TargetPosCoordinates;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is StaticCameraTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StopTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StopTrigger.cs
@@ -47,5 +47,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.TargetGroupID = TargetGroupID;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as StopTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is StopTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StopTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StopTrigger.cs
@@ -56,8 +56,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             return base.EqualsInherited(other)
                 && targetGroupID == z.targetGroupID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is StopTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StopTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/StopTrigger.cs
@@ -44,7 +44,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as StopTrigger;
-            c.TargetGroupID = TargetGroupID;
+            c.targetGroupID = targetGroupID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ToggleTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ToggleTrigger.cs
@@ -57,5 +57,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.ActivateGroup = ActivateGroup;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as ToggleTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is ToggleTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ToggleTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ToggleTrigger.cs
@@ -65,8 +65,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             return base.EqualsInherited(other)
                 && targetGroupID == z.targetGroupID;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is ToggleTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ToggleTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ToggleTrigger.cs
@@ -53,8 +53,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as ToggleTrigger;
-            c.TargetGroupID = TargetGroupID;
-            c.ActivateGroup = ActivateGroup;
+            c.targetGroupID = targetGroupID;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/TouchTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/TouchTrigger.cs
@@ -81,8 +81,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && targetGroupID == z.targetGroupID
                 && ToggleMode == z.ToggleMode;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is TouchTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/TouchTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/TouchTrigger.cs
@@ -73,5 +73,17 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.ToggleMode = ToggleMode;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as TouchTrigger;
+            return base.EqualsInherited(other)
+                && targetGroupID == z.targetGroupID;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is TouchTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/TouchTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/TouchTrigger.cs
@@ -67,9 +67,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as TouchTrigger;
-            c.TargetGroupID = TargetGroupID;
-            c.HoldMode = HoldMode;
-            c.DualMode = DualMode;
+            c.targetGroupID = targetGroupID;
             c.ToggleMode = ToggleMode;
             return base.AddClonedInstanceInformation(c);
         }
@@ -80,7 +78,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         {
             var z = other as TouchTrigger;
             return base.EqualsInherited(other)
-                && targetGroupID == z.targetGroupID;
+                && targetGroupID == z.targetGroupID
+                && ToggleMode == z.ToggleMode;
         }
         /// <summary>Determines whether this object's type is the same as another object's type</summary>
         /// <param name="other">The other object to check whether its type is the same as this one's.</param>

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
@@ -65,7 +65,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             return base.AddClonedInstanceInformation(c);
         }
 
-        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function before returning the result. That means an <see langword="override"/> should look like <see langword="return"/> ... &amp;&amp; <see langword="base"/>.EqualsInherited(<paramref name="other"/>);.</summary>
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
         /// <param name="other">The other object to check whether it equals this object's properties.</param>
         protected override bool EqualsInherited(GeneralObject other)
         {

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
@@ -64,5 +64,13 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.MultiTrigger = MultiTrigger;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function before returning the result. That means an <see langword="override"/> should look like <see langword="return"/> ... &amp;&amp; <see langword="base"/>.EqualsInherited(<paramref name="other"/>);.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            return TriggerBools == (other as Trigger).TriggerBools
+                && base.EqualsInherited(other);
+        }
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/Trigger.cs
@@ -59,9 +59,7 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as Trigger;
-            c.TouchTriggered = TouchTriggered;
-            c.SpawnTriggered = SpawnTriggered;
-            c.MultiTrigger = MultiTrigger;
+            c.TriggerBools = TriggerBools;
             return base.AddClonedInstanceInformation(c);
         }
 

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ZoomTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ZoomTrigger.cs
@@ -55,8 +55,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         protected override GeneralObject AddClonedInstanceInformation(GeneralObject cloned)
         {
             var c = cloned as ZoomTrigger;
-            c.Duration = Duration;
-            c.Zoom = Zoom;
+            c.duration = duration;
+            c.zoom = zoom;
             return base.AddClonedInstanceInformation(c);
         }
 
@@ -66,8 +66,8 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
         {
             var z = other as ZoomTrigger;
             return base.EqualsInherited(other)
-                && zoom == z.zoom
-                && duration == z.duration;
+                && duration == z.duration
+                && zoom == z.zoom;
         }
         /// <summary>Determines whether this object's type is the same as another object's type</summary>
         /// <param name="other">The other object to check whether its type is the same as this one's.</param>

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ZoomTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ZoomTrigger.cs
@@ -69,8 +69,5 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
                 && duration == z.duration
                 && zoom == z.zoom;
         }
-        /// <summary>Determines whether this object's type is the same as another object's type</summary>
-        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
-        protected override bool EqualsType(GeneralObject other) => other is ZoomTrigger;
     }
 }

--- a/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ZoomTrigger.cs
+++ b/GDEdit/GDEdit/Utilities/Objects/GeometryDash/LevelObjects/Triggers/ZoomTrigger.cs
@@ -59,5 +59,18 @@ namespace GDEdit.Utilities.Objects.GeometryDash.LevelObjects.Triggers
             c.Zoom = Zoom;
             return base.AddClonedInstanceInformation(c);
         }
+
+        /// <summary>Determines whether this object equals another object's properties; has to be <see langword="override"/>n in every object and every <see langword="override"/> should call its parent function first before determining its own <see langword="override"/>n result. That means an <see langword="override"/> should look like <see langword="return"/> <see langword="base"/>.EqualsInherited(<paramref name="other"/>) &amp;&amp; ...;.</summary>
+        /// <param name="other">The other object to check whether it equals this object's properties.</param>
+        protected override bool EqualsInherited(GeneralObject other)
+        {
+            var z = other as ZoomTrigger;
+            return base.EqualsInherited(other)
+                && zoom == z.zoom
+                && duration == z.duration;
+        }
+        /// <summary>Determines whether this object's type is the same as another object's type</summary>
+        /// <param name="other">The other object to check whether its type is the same as this one's.</param>
+        protected override bool EqualsType(GeneralObject other) => other is ZoomTrigger;
     }
 }


### PR DESCRIPTION
Also implements equality between some utility objects that are used in level objects.

P.S. I am fully aware of the terribleness of the implementation in `SymmetricRangeMethods`, but you can only blame the language for that.